### PR TITLE
[ci] Add workflow linting and test caller workflow

### DIFF
--- a/.github/workflows/lint-workflows.yml
+++ b/.github/workflows/lint-workflows.yml
@@ -1,0 +1,35 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+# Lint all workflow YAML files on every push and pull request.
+
+name: Lint Workflows
+
+on:
+  push:
+    branches: ["main"]
+    paths: [".github/workflows/**"]
+  pull_request:
+    branches: ["main"]
+    paths: [".github/workflows/**"]
+
+jobs:
+  actionlint:
+    name: actionlint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install actionlint
+        run: |
+          ACTIONLINT_VERSION="1.7.11"
+          EXPECTED_SHA="900919a84f2229bac68ca9cd4103ea297abc35e9689ebb842c6e34a3d1b01b0a"
+          TARBALL="actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+          curl -sSLO "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/${TARBALL}"
+          echo "${EXPECTED_SHA}  ${TARBALL}" | sha256sum -c -
+          tar xz -f "${TARBALL}" actionlint
+          install actionlint /usr/local/bin/actionlint
+          rm -f "${TARBALL}" actionlint
+
+      - name: Run actionlint
+        run: actionlint -color

--- a/.github/workflows/test-nanvix-ci.yml
+++ b/.github/workflows/test-nanvix-ci.yml
@@ -1,0 +1,43 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+# Test caller for the reusable nanvix-ci workflow.
+# Trigger manually via workflow_dispatch to validate changes to the
+# reusable workflow before merging. Uses a minimal matrix to keep
+# runtime short.
+
+name: Test Nanvix CI
+
+on:
+  workflow_dispatch:
+    inputs:
+      zutil-version:
+        description: nanvix-zutil version to install (e.g. v0.4.0).
+        required: true
+        default: "v0.4.0"
+        type: string
+      platforms:
+        description: JSON array of target platforms (default is minimal).
+        required: false
+        default: '["hyperlight"]'
+        type: string
+      process-modes:
+        description: JSON array of deployment modes (default is minimal).
+        required: false
+        default: '["single-process"]'
+        type: string
+
+permissions:
+  contents: write
+  actions: read
+
+jobs:
+  ci:
+    uses: ./.github/workflows/nanvix-ci.yml
+    with:
+      zutil-version: ${{ inputs.zutil-version }}
+      platforms: ${{ inputs.platforms }}
+      process-modes: ${{ inputs.process-modes }}
+      caller-event-name: ${{ github.event_name }}
+    secrets:
+      GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Add static analysis and manual testing capabilities for the reusable workflows in this repo.

## Changes

### `lint-workflows.yml` — Actionlint CI gate
- Runs on every push and PR to `main` that touches `.github/workflows/**`
- Installs and runs [`actionlint`](https://github.com/rhysd/actionlint) to catch syntax errors, bad expressions, invalid `needs`/`if` logic, and other common workflow issues before merge

### `test-nanvix-ci.yml` — Manual test caller
- A `workflow_dispatch` caller for the reusable `nanvix-ci.yml` workflow
- Uses a minimal matrix by default (hyperlight, single-process) for quick validation
- All inputs are configurable at dispatch time for broader testing when needed

## Motivation

Reusable workflows cannot be unit-tested in the traditional sense, but these two additions provide the next best thing: static validation on every change and on-demand end-to-end execution against the real GitHub Actions runner.