### PR TITLE
[ci] F: Add matrix-exclude input to reusable CI workflow

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -29,6 +29,13 @@ on:
         required: false
         default: '["128mb"]'
         type: string
+      matrix-exclude:
+        description: >
+          JSON array of {platform, process-mode} objects to exclude from the
+          build matrix. Example: [{"platform":"hyperlight","process-mode":"single-process"}]
+        required: false
+        default: "[]"
+        type: string
       standalone-test-args:
         description: Extra args passed to ./z test -- for modes in skip-full-test-modes.
         required: false
@@ -113,6 +120,7 @@ jobs:
         platform: ${{ fromJSON(inputs.platforms) }}
         process-mode: ${{ fromJSON(inputs.process-modes) }}
         memory: ${{ fromJSON(inputs.memory-sizes) }}
+        exclude: ${{ fromJSON(inputs.matrix-exclude) }}
     name: ${{ matrix.platform }}-${{ matrix.process-mode }}-${{ matrix.memory }}
     container:
       image: nanvix/toolchain:latest-minimal


### PR DESCRIPTION
## Summary

Add a `matrix-exclude` input to the reusable `nanvix-ci.yml` workflow, allowing callers to exclude specific platform × process-mode combinations from the build matrix.

## Changes

- New `matrix-exclude` input: accepts a JSON array of `{platform, process-mode}` objects (defaults to `[]`)
- Wired into the `build` job matrix strategy via `exclude: ${{ fromJSON(inputs.matrix-exclude) }}`

## Usage

```yaml
jobs:
  ci:
    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.2.0
    with:
      zutil-version: "v0.4.0"
      matrix-exclude: >-
        [
          {"platform":"hyperlight","process-mode":"single-process"},
          {"platform":"hyperlight","process-mode":"multi-process"}
        ]
      caller-event-name: ${{ github.event_name }}
```

This keeps `hyperlight-standalone` enabled while excluding the failing `hyperlight-single-process` and `hyperlight-multi-process` jobs.

## Backward Compatibility

Defaults to an empty array — existing callers are unaffected.