### PR TITLE
[ci] Fix git push auth in zutils updater

### DIFF
--- a/.github/workflows/nanvix-update-zutils.yml
+++ b/.github/workflows/nanvix-update-zutils.yml
@@ -106,10 +106,10 @@ jobs:
             git checkout -B "$BRANCH"
             git commit -m "$COMMIT_MSG"
 
-            # Push using DISPATCH_TOKEN credentials without embedding
-            # the token in the remote URL.
-            git -c "http.extraheader=AUTHORIZATION: bearer ${DISPATCH_TOKEN}" \
-              push origin "$BRANCH" --force 2>&1 || return 1
+            # Push using a one-off authenticated URL to avoid
+            # persisting the token in .git/config.
+            git push "https://x-access-token:${DISPATCH_TOKEN}@github.com/${REPO}.git" \
+              "$BRANCH" --force 2>&1 || return 1
 
             # Open or refresh a PR.
             local PR_TITLE="[ci] E: Update zutil-version to ${LATEST_TAG}"


### PR DESCRIPTION
## Summary

Fix git push authentication in `nanvix-update-zutils.yml`. The `http.extraheader` approach fails with:

```
fatal: could not read Username for 'https://github.com': No such device or address
```

### Fix

Replace `http.extraheader` with the token-in-URL approach (`x-access-token:${DISPATCH_TOKEN}`), matching the proven pattern used by `nanvix-update-workflows.yml`. The cloned repos live in a temp directory that is cleaned up at the end of the workflow run.