### PR TITLE
Replace dynamic admin resolution and add dedup notification

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -64,6 +64,14 @@ on:
         required: false
         default: ""
         type: string
+      failure-assignees:
+        description: >
+          Comma-separated GitHub usernames to assign on CI failure issues.
+          Replaces dynamic admin resolution which requires elevated token
+          permissions not available via GITHUB_TOKEN.
+        required: false
+        default: "ppenna"
+        type: string
     secrets:
       GH_TOKEN:
         description: >
@@ -264,9 +272,8 @@ jobs:
             --description "Automated: CI workflow failure" \
             --color "D73A4A" 2>/dev/null || true
 
-          # Resolve repo admins for assignment using collaborators with admin permission.
-          ADMINS=$(gh api "repos/${REPO}/collaborators?permission=admin" \
-            --paginate --jq '[.[].login] | join(",")' 2>/dev/null || true)
+          # Use the caller-supplied assignee list (defaults to "ppenna").
+          ADMINS="${{ inputs.failure-assignees }}"
 
           # Build the occurrence entry for this failure.
           OCCURRENCE="| ${TIMESTAMP} | ${EVENT} | ${NANVIX_VER} | ${FAILED_JOBS} | [#${{ github.run_number }}](${RUN_URL}) | [\`${GITHUB_SHA::7}\`](${{ github.server_url }}/${REPO}/commit/${{ github.sha }}) |"
@@ -293,7 +300,17 @@ jobs:
             gh issue edit "$ISSUE_NUM" \
               --repo "$REPO" \
               --body "$NEW_BODY"
-            echo "Updated existing issue #${ISSUE_NUM} with new occurrence."
+
+            # Post a comment so GitHub sends notifications to assignees/subscribers.
+            gh issue comment "$ISSUE_NUM" \
+              --repo "$REPO" \
+              --body "🔴 **New CI failure recorded** (${TIMESTAMP})
+
+          | Trigger | Nanvix Version | Failed Jobs | Run |
+          |---------|----------------|-------------|-----|
+          | ${EVENT} | ${NANVIX_VER} | ${FAILED_JOBS} | [#${{ github.run_number }}](${RUN_URL}) |"
+
+            echo "Updated existing issue #${ISSUE_NUM} with new occurrence and comment."
             exit 0
           fi
 

--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -274,8 +274,10 @@ jobs:
             --description "Automated: CI workflow failure" \
             --color "D73A4A" 2>/dev/null || true
 
-          # Use the caller-supplied assignee list (defaults to "ppenna").
+          # Use the caller-supplied assignee list.
           ADMINS="$FAILURE_ASSIGNEES"
+          # Normalize: trim whitespace and strip leading @
+          ADMINS=$(echo "$ADMINS" | tr ',' '\n' | sed 's/^[[:space:]]*@\{0,1\}//; s/[[:space:]]*$//' | tr '\n' ',' | sed 's/,$//')
 
           # Build the occurrence entry for this failure.
           OCCURRENCE="| ${TIMESTAMP} | ${EVENT} | ${NANVIX_VER} | ${FAILED_JOBS} | [#${{ github.run_number }}](${RUN_URL}) | [\`${GITHUB_SHA::7}\`](${{ github.server_url }}/${REPO}/commit/${{ github.sha }}) |"
@@ -304,7 +306,7 @@ jobs:
               --body "$NEW_BODY"
 
             # Post a comment so GitHub sends notifications to assignees/subscribers.
-            printf -v COMMENT_BODY '🔴 **New CI failure recorded** (%s)\n\n| Trigger | Nanvix Version | Failed Jobs | Run |\n|---------|----------------|-------------|-----|\n| %s | %s | %s | [#${{ github.run_number }}](%s) |' \
+            printf -v COMMENT_BODY '🔴 **New CI failure recorded** (%s)\n\n- **Trigger:** %s\n- **Nanvix Version:** %s\n- **Failed Jobs:** %s\n- **Run:** [#${{ github.run_number }}](%s)' \
               "$TIMESTAMP" \
               "$EVENT" \
               "$NANVIX_VER" \

--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -255,6 +255,8 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN || github.token }}
           FAILED_JOBS: ${{ steps.failed.outputs.jobs }}
+          FAILURE_ASSIGNEES: ${{ inputs.failure-assignees }}
+          CALLER_EVENT: ${{ inputs.caller-event-name }}
         run: |
           set -euo pipefail
 
@@ -264,7 +266,7 @@ jobs:
           TITLE="CI: Workflow failure (nanvix ${NANVIX_VER})"
           LABEL="ci-failure"
           TIMESTAMP="$(date -u '+%Y-%m-%d %H:%M UTC')"
-          EVENT="${{ inputs.caller-event-name }}"
+          EVENT="$CALLER_EVENT"
 
           # Ensure the label exists.
           gh label create "$LABEL" \
@@ -273,7 +275,7 @@ jobs:
             --color "D73A4A" 2>/dev/null || true
 
           # Use the caller-supplied assignee list (defaults to "ppenna").
-          ADMINS="${{ inputs.failure-assignees }}"
+          ADMINS="$FAILURE_ASSIGNEES"
 
           # Build the occurrence entry for this failure.
           OCCURRENCE="| ${TIMESTAMP} | ${EVENT} | ${NANVIX_VER} | ${FAILED_JOBS} | [#${{ github.run_number }}](${RUN_URL}) | [\`${GITHUB_SHA::7}\`](${{ github.server_url }}/${REPO}/commit/${{ github.sha }}) |"
@@ -302,13 +304,15 @@ jobs:
               --body "$NEW_BODY"
 
             # Post a comment so GitHub sends notifications to assignees/subscribers.
+            printf -v COMMENT_BODY '🔴 **New CI failure recorded** (%s)\n\n| Trigger | Nanvix Version | Failed Jobs | Run |\n|---------|----------------|-------------|-----|\n| %s | %s | %s | [#${{ github.run_number }}](%s) |' \
+              "$TIMESTAMP" \
+              "$EVENT" \
+              "$NANVIX_VER" \
+              "$FAILED_JOBS" \
+              "$RUN_URL"
             gh issue comment "$ISSUE_NUM" \
               --repo "$REPO" \
-              --body "🔴 **New CI failure recorded** (${TIMESTAMP})
-
-          | Trigger | Nanvix Version | Failed Jobs | Run |
-          |---------|----------------|-------------|-----|
-          | ${EVENT} | ${NANVIX_VER} | ${FAILED_JOBS} | [#${{ github.run_number }}](${RUN_URL}) |"
+              --body "$COMMENT_BODY"
 
             echo "Updated existing issue #${ISSUE_NUM} with new occurrence and comment."
             exit 0


### PR DESCRIPTION
## Summary

Fixes the remaining 2 of 4 chained breaks that suppress CI failure notifications (break #2 was already fixed in v1.5.0, break #1 is fixed in the companion nanvix/zutils PR).

- **Break #3 — dynamic admin resolution fails silently:** Replace `gh api` collaborators call (which returns 403 with `GITHUB_TOKEN`) with a new `failure-assignees` input (default: `"ppenna"`)
- **Break #4 — issue dedup suppresses notifications:** Add `gh issue comment` after `gh issue edit` on the dedup path so GitHub sends notifications to assignees/subscribers

## Changes

| File | Change |
|------|--------|
| `.github/workflows/nanvix-ci.yml` | Add `failure-assignees` input; replace dynamic admin resolution; add notification comment on dedup |

## Post-merge

After merging, tag `v1.6.0` so the companion nanvix/zutils PR can reference it:
```bash
git tag v1.6.0
git push origin v1.6.0
```

Closes #25