### PR TITLE
[ci] E: Fire workflow-ref update on tag push

### DIFF
--- a/.github/workflows/nanvix-update-workflows.yml
+++ b/.github/workflows/nanvix-update-workflows.yml
@@ -68,6 +68,7 @@ jobs:
           COMMIT_MSG="[ci] E: Update nanvix workflow refs to ${LATEST_TAG}"
 
           declare -a UPDATED_REPOS=()
+          declare -a UPDATED_PRS=()
           declare -a SKIPPED_REPOS=()
           declare -a FAILED_REPOS=()
 
@@ -161,6 +162,7 @@ jobs:
             fi
 
             UPDATED_REPOS+=("$REPO")
+            UPDATED_PRS+=("https://github.com/${REPO}/pull/${LATEST_PR}")
             popd >/dev/null
           }
 
@@ -187,7 +189,7 @@ jobs:
             if [ "${#UPDATED_REPOS[@]}" -gt 0 ]; then
               echo ""
               echo "### PRs opened or updated"
-              for R in "${UPDATED_REPOS[@]}"; do echo "- $R"; done
+              for i in "${!UPDATED_REPOS[@]}"; do echo "- ${UPDATED_REPOS[$i]} — ${UPDATED_PRS[$i]}"; done
             fi
 
             if [ "${#SKIPPED_REPOS[@]}" -gt 0 ]; then

--- a/.github/workflows/nanvix-update-workflows.yml
+++ b/.github/workflows/nanvix-update-workflows.yml
@@ -10,6 +10,9 @@
 name: Update Workflow Refs
 
 on:
+  push:
+    tags:
+      - "v*"
   schedule:
     - cron: "0 2 * * *"
   workflow_dispatch:

--- a/.github/workflows/nanvix-update-workflows.yml
+++ b/.github/workflows/nanvix-update-workflows.yml
@@ -20,6 +20,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: update-workflow-refs
+  cancel-in-progress: true
+
 jobs:
   update-refs:
     name: Update workflow refs
@@ -67,8 +71,7 @@ jobs:
           BRANCH="automation/update-nanvix-workflows"
           COMMIT_MSG="[ci] E: Update nanvix workflow refs to ${LATEST_TAG}"
 
-          declare -a UPDATED_REPOS=()
-          declare -a UPDATED_PRS=()
+          declare -a UPDATED_ITEMS=()
           declare -a SKIPPED_REPOS=()
           declare -a FAILED_REPOS=()
 
@@ -161,8 +164,7 @@ jobs:
                 --add-reviewer "$ASSIGNEE" 2>/dev/null || true
             fi
 
-            UPDATED_REPOS+=("$REPO")
-            UPDATED_PRS+=("https://github.com/${REPO}/pull/${LATEST_PR}")
+            UPDATED_ITEMS+=("${REPO} — https://github.com/${REPO}/pull/${LATEST_PR}")
             popd >/dev/null
           }
 
@@ -186,10 +188,10 @@ jobs:
             echo ""
             echo "**Target tag:** \`$LATEST_TAG\`"
 
-            if [ "${#UPDATED_REPOS[@]}" -gt 0 ]; then
+            if [ "${#UPDATED_ITEMS[@]}" -gt 0 ]; then
               echo ""
               echo "### PRs opened or updated"
-              for i in "${!UPDATED_REPOS[@]}"; do echo "- ${UPDATED_REPOS[$i]} — ${UPDATED_PRS[$i]}"; done
+              for R in "${UPDATED_ITEMS[@]}"; do echo "- $R"; done
             fi
 
             if [ "${#SKIPPED_REPOS[@]}" -gt 0 ]; then


### PR DESCRIPTION
## Summary

Adds a `push.tags: ['v*']` trigger to `nanvix-update-workflows.yml` so downstream consumer repos get their workflow-ref update PRs immediately when a new release tag is pushed, instead of waiting up to 23 hours for the daily cron.

Companion to PR #30 — that PR adds `automation/update-nanvix-workflows` to the auto-merge allow-list so the resulting PRs are auto-merged after CI passes.

## Changes

```diff
 on:
+  push:
+    tags:
+      - "v*"
   schedule:
     - cron: "0 2 * * *"
   workflow_dispatch:
```

Closes #33