### PR TITLE
fix(ci): use explicit inputs for auto-merge fork protection

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -517,6 +517,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Dump context values
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+          BASE_REF: ${{ github.base_ref }}
+          REF_NAME: ${{ github.ref_name }}
+          EVENT_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          EVENT_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          EVENT_BASE_REF: ${{ github.event.pull_request.base.ref }}
+          EVENT_BASE_REPO: ${{ github.event.pull_request.base.repo.full_name }}
+          HEAD_REF_MATCH: ${{ github.head_ref == 'automation/update-zutils-version' || github.head_ref == 'automation/update-nanvix-version' || github.head_ref == 'automation/update-nanvix-workflows' }}
+          OLD_HEAD_REF_MATCH: ${{ github.event.pull_request.head.ref == 'automation/update-zutils-version' || github.event.pull_request.head.ref == 'automation/update-nanvix-version' || github.event.pull_request.head.ref == 'automation/update-nanvix-workflows' }}
         run: |
           echo "=== Inputs ==="
           echo "caller-event-name: ${{ inputs.caller-event-name }}"
@@ -525,10 +535,10 @@ jobs:
           echo "=== Top-level github context ==="
           echo "github.repository: ${{ github.repository }}"
           echo "github.event_name: ${{ github.event_name }}"
-          echo "github.head_ref: ${{ github.head_ref }}"
-          echo "github.base_ref: ${{ github.base_ref }}"
+          echo "github.head_ref: $HEAD_REF"
+          echo "github.base_ref: $BASE_REF"
           echo "github.ref: ${{ github.ref }}"
-          echo "github.ref_name: ${{ github.ref_name }}"
+          echo "github.ref_name: $REF_NAME"
           echo ""
           echo "=== Shallow event properties ==="
           echo "github.event.number: ${{ github.event.number }}"
@@ -536,17 +546,17 @@ jobs:
           echo ""
           echo "=== Deeply nested event properties ==="
           echo "github.event.pull_request.number: ${{ github.event.pull_request.number }}"
-          echo "github.event.pull_request.head.ref: ${{ github.event.pull_request.head.ref }}"
-          echo "github.event.pull_request.head.repo.full_name: ${{ github.event.pull_request.head.repo.full_name }}"
-          echo "github.event.pull_request.base.ref: ${{ github.event.pull_request.base.ref }}"
-          echo "github.event.pull_request.base.repo.full_name: ${{ github.event.pull_request.base.repo.full_name }}"
+          echo "github.event.pull_request.head.ref: $EVENT_HEAD_REF"
+          echo "github.event.pull_request.head.repo.full_name: $EVENT_HEAD_REPO"
+          echo "github.event.pull_request.base.ref: $EVENT_BASE_REF"
+          echo "github.event.pull_request.base.repo.full_name: $EVENT_BASE_REPO"
           echo ""
           echo "=== Condition evaluation ==="
           echo "ci-passed result: ${{ needs.ci-passed.result }}"
           echo "caller-head-repo == github.repository: ${{ inputs.caller-head-repo == github.repository }}"
-          echo "head_ref match: ${{ github.head_ref == 'automation/update-zutils-version' || github.head_ref == 'automation/update-nanvix-version' || github.head_ref == 'automation/update-nanvix-workflows' }}"
+          echo "head_ref match: $HEAD_REF_MATCH"
           echo "OLD deep full_name == repository: ${{ github.event.pull_request.head.repo.full_name == github.repository }}"
-          echo "OLD deep head.ref match: ${{ github.event.pull_request.head.ref == 'automation/update-zutils-version' || github.event.pull_request.head.ref == 'automation/update-nanvix-version' || github.event.pull_request.head.ref == 'automation/update-nanvix-workflows' }}"
+          echo "OLD deep head.ref match: $OLD_HEAD_REF_MATCH"
 
   # -------------------------------------------------------------------
   # Job 7: Auto-merge automation PRs after CI passes

--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -59,15 +59,6 @@ on:
           reusable workflow always sees "workflow_call".
         required: true
         type: string
-      caller-head-repo:
-        description: >
-          github.event.pull_request.head.repo.full_name from the caller.
-          Used by the auto-merge job to verify the PR originates from the
-          same repository (fork protection). Pass an empty string for
-          non-pull_request events.
-        required: false
-        default: ""
-        type: string
       release-notes-extra:
         description: Extra markdown to append to the release notes.
         required: false
@@ -530,7 +521,6 @@ jobs:
         run: |
           echo "=== Inputs ==="
           echo "caller-event-name: ${{ inputs.caller-event-name }}"
-          echo "caller-head-repo: ${{ inputs.caller-head-repo }}"
           echo ""
           echo "=== Top-level github context ==="
           echo "github.repository: ${{ github.repository }}"
@@ -553,7 +543,6 @@ jobs:
           echo ""
           echo "=== Condition evaluation ==="
           echo "ci-passed result: ${{ needs.ci-passed.result }}"
-          echo "caller-head-repo == github.repository: ${{ inputs.caller-head-repo == github.repository }}"
           echo "head_ref match: $HEAD_REF_MATCH"
           echo "OLD deep full_name == repository: ${{ github.event.pull_request.head.repo.full_name == github.repository }}"
           echo "OLD deep head.ref match: $OLD_HEAD_REF_MATCH"
@@ -566,7 +555,6 @@ jobs:
     if: >-
       needs.ci-passed.result == 'success'
       && inputs.caller-event-name == 'pull_request'
-      && inputs.caller-head-repo == github.repository
       && (github.head_ref == 'automation/update-zutils-version'
           || github.head_ref == 'automation/update-nanvix-version'
           || github.head_ref == 'automation/update-nanvix-workflows')
@@ -578,6 +566,13 @@ jobs:
           PR_NUMBER: ${{ github.event.number }}
           REPO: ${{ github.repository }}
         run: |
+          # Fork protection: verify the PR head repo matches this repo.
+          HEAD_REPO=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json headRepositoryOwner,headRepository --jq '"\(.headRepositoryOwner.login)/\(.headRepository.name)"')
+          if [[ "$HEAD_REPO" != "$REPO" ]]; then
+            echo "::warning::PR #$PR_NUMBER head repo ($HEAD_REPO) does not match $REPO — skipping auto-merge"
+            exit 0
+          fi
+
           echo "Merging automation PR #$PR_NUMBER on $REPO..."
           gh pr merge "$PR_NUMBER" --repo "$REPO" --squash --delete-branch || {
             echo "::warning::Auto-merge failed for PR #$PR_NUMBER"

--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -567,7 +567,10 @@ jobs:
           REPO: ${{ github.repository }}
         run: |
           # Fork protection: verify the PR head repo matches this repo.
-          HEAD_REPO=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json headRepositoryOwner,headRepository --jq '"\(.headRepositoryOwner.login)/\(.headRepository.name)"')
+          if ! HEAD_REPO=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json headRepositoryOwner,headRepository --jq '"\(.headRepositoryOwner.login)/\(.headRepository.name)"') || [[ -z "$HEAD_REPO" ]]; then
+            echo "::error::Failed to resolve head repo for PR #$PR_NUMBER — aborting auto-merge"
+            exit 1
+          fi
           if [[ "$HEAD_REPO" != "$REPO" ]]; then
             echo "::warning::PR #$PR_NUMBER head repo ($HEAD_REPO) does not match $REPO — skipping auto-merge"
             exit 0

--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -59,6 +59,15 @@ on:
           reusable workflow always sees "workflow_call".
         required: true
         type: string
+      caller-head-repo:
+        description: >
+          github.event.pull_request.head.repo.full_name from the caller.
+          Used by the auto-merge job to verify the PR originates from the
+          same repository (fork protection). Pass an empty string for
+          non-pull_request events.
+        required: false
+        default: ""
+        type: string
       release-notes-extra:
         description: Extra markdown to append to the release notes.
         required: false
@@ -498,6 +507,48 @@ jobs:
           done
 
   # -------------------------------------------------------------------
+  # Job 6b: Debug context visibility (temporary — remove after confirming)
+  # -------------------------------------------------------------------
+  debug-context:
+    needs: ci-passed
+    if: >-
+      always()
+      && inputs.caller-event-name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dump context values
+        run: |
+          echo "=== Inputs ==="
+          echo "caller-event-name: ${{ inputs.caller-event-name }}"
+          echo "caller-head-repo: ${{ inputs.caller-head-repo }}"
+          echo ""
+          echo "=== Top-level github context ==="
+          echo "github.repository: ${{ github.repository }}"
+          echo "github.event_name: ${{ github.event_name }}"
+          echo "github.head_ref: ${{ github.head_ref }}"
+          echo "github.base_ref: ${{ github.base_ref }}"
+          echo "github.ref: ${{ github.ref }}"
+          echo "github.ref_name: ${{ github.ref_name }}"
+          echo ""
+          echo "=== Shallow event properties ==="
+          echo "github.event.number: ${{ github.event.number }}"
+          echo "github.event.action: ${{ github.event.action }}"
+          echo ""
+          echo "=== Deeply nested event properties ==="
+          echo "github.event.pull_request.number: ${{ github.event.pull_request.number }}"
+          echo "github.event.pull_request.head.ref: ${{ github.event.pull_request.head.ref }}"
+          echo "github.event.pull_request.head.repo.full_name: ${{ github.event.pull_request.head.repo.full_name }}"
+          echo "github.event.pull_request.base.ref: ${{ github.event.pull_request.base.ref }}"
+          echo "github.event.pull_request.base.repo.full_name: ${{ github.event.pull_request.base.repo.full_name }}"
+          echo ""
+          echo "=== Condition evaluation ==="
+          echo "ci-passed result: ${{ needs.ci-passed.result }}"
+          echo "caller-head-repo == github.repository: ${{ inputs.caller-head-repo == github.repository }}"
+          echo "head_ref match: ${{ github.head_ref == 'automation/update-zutils-version' || github.head_ref == 'automation/update-nanvix-version' || github.head_ref == 'automation/update-nanvix-workflows' }}"
+          echo "OLD deep full_name == repository: ${{ github.event.pull_request.head.repo.full_name == github.repository }}"
+          echo "OLD deep head.ref match: ${{ github.event.pull_request.head.ref == 'automation/update-zutils-version' || github.event.pull_request.head.ref == 'automation/update-nanvix-version' || github.event.pull_request.head.ref == 'automation/update-nanvix-workflows' }}"
+
+  # -------------------------------------------------------------------
   # Job 7: Auto-merge automation PRs after CI passes
   # -------------------------------------------------------------------
   auto-merge:
@@ -505,16 +556,16 @@ jobs:
     if: >-
       needs.ci-passed.result == 'success'
       && inputs.caller-event-name == 'pull_request'
-      && github.event.pull_request.head.repo.full_name == github.repository
-      && (github.event.pull_request.head.ref == 'automation/update-zutils-version'
-          || github.event.pull_request.head.ref == 'automation/update-nanvix-version'
-          || github.event.pull_request.head.ref == 'automation/update-nanvix-workflows')
+      && inputs.caller-head-repo == github.repository
+      && (github.head_ref == 'automation/update-zutils-version'
+          || github.head_ref == 'automation/update-nanvix-version'
+          || github.head_ref == 'automation/update-nanvix-workflows')
     runs-on: ubuntu-latest
     steps:
       - name: Merge automation PR
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_NUMBER: ${{ github.event.number }}
           REPO: ${{ github.repository }}
         run: |
           echo "Merging automation PR #$PR_NUMBER on $REPO..."

--- a/.github/workflows/nanvix-update-workflows.yml
+++ b/.github/workflows/nanvix-update-workflows.yml
@@ -99,6 +99,14 @@ jobs:
               [ -f "$FILE" ] || continue
               if grep -qE 'uses:[[:space:]]*nanvix/workflows/.+@v[^[:space:]#]+' "$FILE"; then
                 sed -i -E "s|(uses:[[:space:]]*nanvix/workflows/.+)@v[^[:space:]#]+|\1@${LATEST_TAG}|g" "$FILE"
+
+                # Inject caller-head-repo input if not already present.
+                # Required by the auto-merge job in the reusable workflow
+                # for fork protection (v1.7.1+).
+                if grep -q 'caller-event-name:' "$FILE" && ! grep -q 'caller-head-repo:' "$FILE"; then
+                  sed -i '/caller-event-name:/a\      caller-head-repo: ${{ github.event.pull_request.head.repo.full_name || '\'''\'' }}' "$FILE"
+                fi
+
                 if ! git diff --quiet -- "$FILE"; then
                   git add "$FILE"
                   CHANGED=1

--- a/.github/workflows/nanvix-update-workflows.yml
+++ b/.github/workflows/nanvix-update-workflows.yml
@@ -100,14 +100,6 @@ jobs:
               if grep -qE 'uses:[[:space:]]*nanvix/workflows/.+@v[^[:space:]#]+' "$FILE"; then
                 sed -i -E "s|(uses:[[:space:]]*nanvix/workflows/.+)@v[^[:space:]#]+|\1@${LATEST_TAG}|g" "$FILE"
 
-                # Inject caller-head-repo input if not already present.
-                # Required by the auto-merge job in the reusable workflow
-                # for fork protection (v1.7.1+).
-                if grep -q 'caller-event-name:' "$FILE" && ! grep -q 'caller-head-repo:' "$FILE"; then
-                  INJECT_LINE="      caller-head-repo: \${{ github.event.pull_request.head.repo.full_name || '' }}"
-                  sed -i "/caller-event-name:/a\\${INJECT_LINE}" "$FILE"
-                fi
-
                 if ! git diff --quiet -- "$FILE"; then
                   git add "$FILE"
                   CHANGED=1

--- a/.github/workflows/nanvix-update-workflows.yml
+++ b/.github/workflows/nanvix-update-workflows.yml
@@ -104,7 +104,8 @@ jobs:
                 # Required by the auto-merge job in the reusable workflow
                 # for fork protection (v1.7.1+).
                 if grep -q 'caller-event-name:' "$FILE" && ! grep -q 'caller-head-repo:' "$FILE"; then
-                  sed -i '/caller-event-name:/a\      caller-head-repo: ${{ github.event.pull_request.head.repo.full_name || '\'''\'' }}' "$FILE"
+                  INJECT_LINE="      caller-head-repo: \${{ github.event.pull_request.head.repo.full_name || '' }}"
+                  sed -i "/caller-event-name:/a\\${INJECT_LINE}" "$FILE"
                 fi
 
                 if ! git diff --quiet -- "$FILE"; then


### PR DESCRIPTION
## Problem

The auto-merge job in the reusable CI workflow is always **skipped** on automation PRs (e.g. [nanvix/zlib#82](https://github.com/nanvix/zlib/pull/82)). The `if` condition uses deeply nested event context properties (`github.event.pull_request.head.repo.full_name`, `github.event.pull_request.head.ref`) which don't resolve inside reusable workflows called via `workflow_call`.

## Fix

- Add `caller-head-repo` input to the reusable workflow, passed explicitly from the caller where the event context is fully available
- Replace `github.event.pull_request.head.ref` with `github.head_ref` (top-level context, reliable in reusable workflows)
- Replace `github.event.pull_request.number` with `github.event.number` (shallow event property)
- Update `nanvix-update-workflows.yml` to inject the new `caller-head-repo` input into consumer caller workflows automatically

## Verification

Includes a temporary `debug-context` job that runs on every PR event and dumps all context values (old deeply nested + new replacements). This will confirm which properties actually resolve. Remove after one successful run.

## Rollout

Once this is tagged (v1.7.1), the update-workflows dispatch will:
1. Bump consumer repos to `@v1.7.1`
2. Inject the `caller-head-repo` input line into their caller workflows
3. Open new automation PRs — which should now auto-merge successfully