### PR TITLE
fix(ci): add always() to auto-merge to prevent transitive skip

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -553,7 +553,8 @@ jobs:
   auto-merge:
     needs: ci-passed
     if: >-
-      needs.ci-passed.result == 'success'
+      always()
+      && needs.ci-passed.result == 'success'
       && inputs.caller-event-name == 'pull_request'
       && (github.head_ref == 'automation/update-zutils-version'
           || github.head_ref == 'automation/update-nanvix-version'


### PR DESCRIPTION
## Problem

Auto-merge job is always skipped on automation PRs despite all condition values being correct (confirmed via the debug-context job added in v1.7.1).

## Root cause

`ci-passed` depends on `[get-nanvix-info, build, release, update-nanvix-version]`. On `pull_request` events, `release` and `update-nanvix-version` are skipped. Even though `ci-passed` uses `always()` and succeeds, GitHub Actions propagates the skipped ancestor status to downstream jobs that don't use `always()`.

The `debug-context` job (which uses `always()`) runs fine. The `auto-merge` job (which didn't) was skipped.

## Fix

Add `always()` to the auto-merge `if:` condition, keeping `needs.ci-passed.result == 'success'` to ensure CI actually passed.

## Evidence

- v1.7.1 debug-context output: https://github.com/nanvix/zlib/actions/runs/24253870300/job/70820554647
- All values resolve correctly, yet auto-merge was skipped