### PR TITLE
fix(ci): use --admin for auto-merge to bypass branch protection

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -578,6 +578,6 @@ jobs:
           fi
 
           echo "Merging automation PR #$PR_NUMBER on $REPO..."
-          gh pr merge "$PR_NUMBER" --repo "$REPO" --squash --delete-branch || {
+          gh pr merge "$PR_NUMBER" --repo "$REPO" --squash --admin --delete-branch || {
             echo "::warning::Auto-merge failed for PR #$PR_NUMBER"
           }


### PR DESCRIPTION
## Problem

Auto-merge job now runs (fixed in v1.7.2) but `gh pr merge` fails because branch protection rules block the merge.

## Fix

Add `--admin` flag to `gh pr merge` to bypass branch protection for automation PRs. The job-level `if` condition already ensures only automation branches on same-repo PRs reach this point.