### PR TITLE
fix(ci): specify --merge strategy for auto-merge

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -578,6 +578,6 @@ jobs:
           fi
 
           echo "Merging automation PR #$PR_NUMBER on $REPO..."
-          gh pr merge "$PR_NUMBER" --repo "$REPO" --admin --delete-branch || {
+          gh pr merge "$PR_NUMBER" --repo "$REPO" --merge --admin --delete-branch || {
             echo "::warning::Auto-merge failed for PR #$PR_NUMBER"
           }


### PR DESCRIPTION
gh pr merge requires an explicit strategy flag. Adds `--merge`.