### PR TITLE
fix(ci): use DISPATCH_TOKEN for auto-merge

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -563,7 +563,7 @@ jobs:
     steps:
       - name: Merge automation PR
         env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GH_TOKEN: ${{ secrets.DISPATCH_TOKEN }}
           PR_NUMBER: ${{ github.event.number }}
           REPO: ${{ github.repository }}
         run: |

--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -79,8 +79,12 @@ on:
           and contents + pull-requests write (for the update-nanvix-version job).
         required: true
       DISPATCH_TOKEN:
-        description: Token with repo scope on downstream repos (for dispatches).
-        required: false
+        description: >
+          Token with repo scope and admin access on consumer repos.
+          Used for downstream dispatches, version update PRs, and
+          auto-merging automation PRs (requires admin to bypass
+          branch protection).
+        required: true
     outputs:
       package_name:
         description: Package name resolved from the manifest.

--- a/.github/workflows/test-nanvix-ci.yml
+++ b/.github/workflows/test-nanvix-ci.yml
@@ -41,3 +41,4 @@ jobs:
       caller-event-name: ${{ github.event_name }}
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
+      DISPATCH_TOKEN: ${{ secrets.DISPATCH_TOKEN }}


### PR DESCRIPTION
GH_TOKEN lacks admin permissions to bypass branch protection. Use DISPATCH_TOKEN which has repo scope.