### PR TITLE
Add nanvix/posix-tests to consumer repos

### DIFF
--- a/consumer-repos.json
+++ b/consumer-repos.json
@@ -5,5 +5,6 @@
   "nanvix/libffi",
   "nanvix/openssl",
   "nanvix/cpython",
-  "nanvix/quickjs"
+  "nanvix/quickjs",
+  "nanvix/posix-tests"
 ]


### PR DESCRIPTION
Include `nanvix/posix-tests` in the automated sync so it receives:
- **zutil-version bumps** (bootstrapper templates, `zutil-version` in CI workflows, `nanvix-version` pin in `nanvix.toml`)
- **Workflow ref updates** (`nanvix/workflows/...@vX.Y.Z` references)

This ensures posix-tests stays in sync with the rest of the Nanvix ecosystem and avoids breakage from upstream naming convention changes (see [posix-tests#13](https://github.com/nanvix/posix-tests/issues/13)).

> **Note:** `posix-tests` will need the new template structure (`z.sh`, `.nanvix/nanvix.toml`, etc.) before the first automated sync runs against it.