### PR TITLE
[ci] Apply tiered schedule to update dispatch workflows

### DIFF
--- a/.github/workflows/nanvix-update-workflows.yml
+++ b/.github/workflows/nanvix-update-workflows.yml
@@ -14,14 +14,23 @@ on:
     tags:
       - "v*"
   schedule:
-    - cron: "0 2 * * *"
+    # Tier-to-repo mapping lives in tier-config.json.
+    - cron: "0 9 * * *"   # Tier 1
+    - cron: "0 10 * * *"  # Tier 2
+    - cron: "0 11 * * *"  # Tier 3
   workflow_dispatch:
 
 permissions:
   contents: read
 
 concurrency:
-  group: update-workflow-refs
+  group: >-
+    update-workflow-refs-${{
+      github.event.schedule == '0 9 * * *' && 'tier1' ||
+      github.event.schedule == '0 10 * * *' && 'tier2' ||
+      github.event.schedule == '0 11 * * *' && 'tier3' ||
+      'all'
+    }}
   cancel-in-progress: true
 
 jobs:
@@ -59,10 +68,18 @@ jobs:
           REPOS=$(jq -c '.' consumer-repos.json)
           echo "default_repos=$REPOS" >> "$GITHUB_OUTPUT"
 
+      - name: Select target repos
+        id: select-repos
+        env:
+          DEFAULT_REPOS: ${{ steps.latest.outputs.default_repos }}
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_SCHEDULE: ${{ github.event.schedule || '' }}
+        run: bash scripts/select-tier-repos.sh
+
       - name: Update target repositories
         env:
           LATEST_TAG: ${{ steps.latest.outputs.tag }}
-          TARGET_REPOS: ${{ steps.latest.outputs.default_repos }}
+          TARGET_REPOS: ${{ steps.select-repos.outputs.repos }}
           DISPATCH_TOKEN: ${{ secrets.DISPATCH_TOKEN }}
         run: |
           set -euo pipefail

--- a/.github/workflows/nanvix-update-zutils.yml
+++ b/.github/workflows/nanvix-update-zutils.yml
@@ -2,9 +2,10 @@
 # Licensed under the MIT License.
 
 # This workflow syncs consumer repositories with the latest nanvix/zutils
-# release. It runs on a daily schedule (03:00 UTC), can be triggered
-# manually via workflow_dispatch, or called from another workflow (e.g.
-# the zutils release pipeline) via workflow_call with an explicit tag.
+# release. It runs on a tiered daily schedule (09:00/10:00/11:00 UTC) that
+# mirrors the consumer CI cascade, can be triggered manually via
+# workflow_dispatch, or called from another workflow (e.g. the zutils
+# release pipeline) via workflow_call with an explicit tag.
 # It resolves the latest release tag of nanvix/zutils (unless one is
 # provided), then iterates over each target repo:
 #   1. Updating `zutil-version: "vOLD"` to `"vLATEST"` in caller workflows.
@@ -18,7 +19,10 @@ name: Update Zutils Version
 
 on:
   schedule:
-    - cron: "0 3 * * *"
+    # Tier-to-repo mapping lives in tier-config.json.
+    - cron: "0 9 * * *"   # Tier 1
+    - cron: "0 10 * * *"  # Tier 2
+    - cron: "0 11 * * *"  # Tier 3
   workflow_dispatch:
   workflow_call:
     inputs:
@@ -35,7 +39,13 @@ permissions:
   contents: read
 
 concurrency:
-  group: update-zutils
+  group: >-
+    update-zutils-${{
+      github.event.schedule == '0 9 * * *' && 'tier1' ||
+      github.event.schedule == '0 10 * * *' && 'tier2' ||
+      github.event.schedule == '0 11 * * *' && 'tier3' ||
+      'all'
+    }}
   cancel-in-progress: true
 
 jobs:
@@ -78,6 +88,14 @@ jobs:
           REPOS=$(jq -c '.' consumer-repos.json)
           echo "default_repos=$REPOS" >> "$GITHUB_OUTPUT"
 
+      - name: Select target repos
+        id: select-repos
+        env:
+          DEFAULT_REPOS: ${{ steps.latest.outputs.default_repos }}
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_SCHEDULE: ${{ github.event.schedule || '' }}
+        run: bash scripts/select-tier-repos.sh
+
       - name: Download bootstrapper templates
         id: templates
         run: |
@@ -109,7 +127,7 @@ jobs:
       - name: Update target repositories
         env:
           LATEST_TAG: ${{ steps.latest.outputs.tag }}
-          TARGET_REPOS: ${{ steps.latest.outputs.default_repos }}
+          TARGET_REPOS: ${{ steps.select-repos.outputs.repos }}
           TEMPLATES_DIR: ${{ steps.templates.outputs.dir }}
           DISPATCH_TOKEN: ${{ secrets.DISPATCH_TOKEN }}
           NANVIX_VERSION: ${{ steps.nanvix.outputs.version }}

--- a/scripts/select-tier-repos.sh
+++ b/scripts/select-tier-repos.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+# Selects the tier-appropriate subset of target repositories based on
+# the GitHub Actions event context.  Reads tier definitions from
+# tier-config.json in the repository root so that the cron-to-repo
+# mapping lives in a single place shared by all dispatch workflows.
+#
+# Required environment variables:
+#   EVENT_NAME     – github.event_name
+#   EVENT_SCHEDULE – github.event.schedule (empty for non-schedule events)
+#   DEFAULT_REPOS  – JSON array of all consumer repos (fallback)
+#
+# Outputs (written to $GITHUB_OUTPUT):
+#   tier  – tier label (e.g. "tier1") or "all"
+#   repos – JSON array of target repo slugs
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CONFIG="${REPO_ROOT}/tier-config.json"
+
+if [ ! -f "$CONFIG" ]; then
+  echo "::error::Tier config not found: $CONFIG"
+  exit 1
+fi
+
+if ! command -v jq &>/dev/null; then
+  echo "::error::jq is required but not installed"
+  exit 1
+fi
+
+# --- Config validation ------------------------------------------------
+
+# No duplicate cron entries.
+DUPLICATE_CRONS=$(jq '[.tiers[].cron] | group_by(.) | map(select(length > 1)) | length' "$CONFIG")
+if [ "$DUPLICATE_CRONS" -ne 0 ]; then
+  echo "::error::Duplicate cron entries in $CONFIG"
+  exit 1
+fi
+
+# No duplicate tier names.
+DUPLICATE_NAMES=$(jq '[.tiers[].name] | group_by(.) | map(select(length > 1)) | length' "$CONFIG")
+if [ "$DUPLICATE_NAMES" -ne 0 ]; then
+  echo "::error::Duplicate tier names in $CONFIG"
+  exit 1
+fi
+
+# Union of tier repos must match consumer-repos.json.
+CONSUMER_REPOS="${REPO_ROOT}/consumer-repos.json"
+if [ -f "$CONSUMER_REPOS" ]; then
+  TIER_REPOS=$(jq -c '[.tiers[].repos[]] | sort | unique' "$CONFIG")
+  ALL_REPOS=$(jq -c 'sort | unique' "$CONSUMER_REPOS")
+  if [ "$TIER_REPOS" != "$ALL_REPOS" ]; then
+    echo "::error::Tier repos in $CONFIG do not match $CONSUMER_REPOS"
+    echo "  Tier repos:     $TIER_REPOS"
+    echo "  Consumer repos: $ALL_REPOS"
+    exit 1
+  fi
+fi
+
+# --- Tier selection ---------------------------------------------------
+
+if [ "$EVENT_NAME" = "schedule" ] && [ -n "${EVENT_SCHEDULE:-}" ]; then
+  TIER=$(jq -r --arg cron "$EVENT_SCHEDULE" \
+    '.tiers[] | select(.cron == $cron) | .name' "$CONFIG")
+
+  if [ -z "$TIER" ]; then
+    echo "::error::Unrecognized schedule '${EVENT_SCHEDULE}'; no matching tier in $CONFIG"
+    exit 1
+  fi
+
+  REPOS=$(jq -c --arg cron "$EVENT_SCHEDULE" \
+    '.tiers[] | select(.cron == $cron) | .repos' "$CONFIG")
+
+  echo "tier=$TIER"  >> "$GITHUB_OUTPUT"
+  echo "repos=$REPOS" >> "$GITHUB_OUTPUT"
+  echo "Selected tier: $TIER (cron: $EVENT_SCHEDULE)"
+else
+  echo "tier=all"              >> "$GITHUB_OUTPUT"
+  echo "repos=$DEFAULT_REPOS"  >> "$GITHUB_OUTPUT"
+  echo "Selected tier: all (event: $EVENT_NAME)"
+fi

--- a/tier-config.json
+++ b/tier-config.json
@@ -1,0 +1,30 @@
+{
+  "tiers": [
+    {
+      "name": "tier1",
+      "cron": "0 9 * * *",
+      "repos": [
+        "nanvix/zlib",
+        "nanvix/bzip2",
+        "nanvix/openssl",
+        "nanvix/quickjs",
+        "nanvix/libffi",
+        "nanvix/posix-tests"
+      ]
+    },
+    {
+      "name": "tier2",
+      "cron": "0 10 * * *",
+      "repos": [
+        "nanvix/sqlite"
+      ]
+    },
+    {
+      "name": "tier3",
+      "cron": "0 11 * * *",
+      "repos": [
+        "nanvix/cpython"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Aligns `nanvix-update-zutils.yml` and `nanvix-update-workflows.yml` with the consumer CI cascade schedule:

| Tier | UTC | PDT | Repos |
|------|-----|-----|-------|
| 1 | 09:00 | 2 AM | zlib, bzip2, openssl, quickjs, libffi, posix-tests |
| 2 | 10:00 | 3 AM | sqlite |
| 3 | 11:00 | 4 AM | cpython |

**What changed:**
- Replaced single daily cron with 3 tiered cron entries
- Added `tier-config.json` as the single source of truth for tier-to-repo mapping
- Added `scripts/select-tier-repos.sh` shared script consumed by both workflows (validates config consistency with `consumer-repos.json`)
- Per-tier concurrency groups use stable tier labels (`tier1`/`tier2`/`tier3`) instead of raw cron strings
- Non-schedule triggers (`workflow_dispatch`, tag push, and `workflow_call` in `nanvix-update-zutils.yml`) continue to process **all** repos in `consumer-repos.json`
- Unknown schedule crons fail instead of silently falling back to all repos