### PR TITLE
[ci] Skip issue creation on pull_request events

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -240,6 +240,7 @@ jobs:
     needs: [get-nanvix-info, build, release, update-nanvix-version]
     if: >-
       always() &&
+      inputs.caller-event-name != 'pull_request' &&
       (needs.build.result != 'success' && needs.build.result != 'skipped'
        || needs.release.result != 'success' && needs.release.result != 'skipped'
        || needs.update-nanvix-version.result != 'success' && needs.update-nanvix-version.result != 'skipped')


### PR DESCRIPTION
## Problem

The `report-failure` job in the reusable `nanvix-ci.yml` workflow creates GitHub issues on **any** CI failure, including failures on PR branches. Issues should only be created for failures on default-branch runs (push, schedule, dispatch).

## Root Cause

The `report-failure` job was missing a guard on `inputs.caller-event-name`. Other jobs (`release`, `update-nanvix-version`) already filter out `pull_request` events, but `report-failure` did not.

## Fix

Add `inputs.caller-event-name != 'pull_request'` to the `report-failure` `if` condition, consistent with the existing guards on sibling jobs.