### PR TITLE
[ci] E: Skip cancelled notify and tag Admin team

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -238,12 +238,14 @@ jobs:
   # -------------------------------------------------------------------
   report-failure:
     needs: [get-nanvix-info, build, release, update-nanvix-version]
+    # Only report true failures (not cancellations from higher-priority runs).
+    # The ci-passed gate intentionally still fails on cancelled for branch protection.
     if: >-
       always() &&
       inputs.caller-event-name != 'pull_request' &&
-      (needs.build.result != 'success' && needs.build.result != 'skipped'
-       || needs.release.result != 'success' && needs.release.result != 'skipped'
-       || needs.update-nanvix-version.result != 'success' && needs.update-nanvix-version.result != 'skipped')
+      (needs.build.result == 'failure'
+       || needs.release.result == 'failure'
+       || needs.update-nanvix-version.result == 'failure')
     runs-on: ubuntu-latest
     steps:
       - name: Identify failed jobs
@@ -257,7 +259,7 @@ jobs:
           do
             JOB="${pair%%:*}"
             RESULT="${pair#*:}"
-            if [[ "$RESULT" != "success" && "$RESULT" != "skipped" ]]; then
+            if [[ "$RESULT" == "failure" ]]; then
               FAILED="${FAILED:+$FAILED, }${JOB} (${RESULT})"
             fi
           done

--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -77,6 +77,14 @@ on:
         required: false
         default: "ppenna"
         type: string
+      failure-notify-team:
+        description: >
+          Org team slug to @-mention on CI failure issues (e.g. "admin").
+          The team is mentioned as @<org>/<slug> so all members are notified.
+          Set to empty string to disable team mentions.
+        required: false
+        default: "admin"
+        type: string
     secrets:
       GH_TOKEN:
         description: >
@@ -271,6 +279,8 @@ jobs:
           FAILED_JOBS: ${{ steps.failed.outputs.jobs }}
           FAILURE_ASSIGNEES: ${{ inputs.failure-assignees }}
           CALLER_EVENT: ${{ inputs.caller-event-name }}
+          ORG: ${{ github.repository_owner }}
+          TEAM_SLUG: ${{ inputs.failure-notify-team }}
         run: |
           set -euo pipefail
 
@@ -320,12 +330,17 @@ jobs:
               --body "$NEW_BODY"
 
             # Post a comment so GitHub sends notifications to assignees/subscribers.
-            printf -v COMMENT_BODY '🔴 **New CI failure recorded** (%s)\n\n- **Trigger:** %s\n- **Nanvix Version:** %s\n- **Failed Jobs:** %s\n- **Run:** [#${{ github.run_number }}](%s)' \
+            TEAM_CC=""
+            if [[ -n "$TEAM_SLUG" ]]; then
+              printf -v TEAM_CC '\n\ncc @%s/%s' "$ORG" "$TEAM_SLUG"
+            fi
+            printf -v COMMENT_BODY '🔴 **New CI failure recorded** (%s)\n\n- **Trigger:** %s\n- **Nanvix Version:** %s\n- **Failed Jobs:** %s\n- **Run:** [#${{ github.run_number }}](%s)%s' \
               "$TIMESTAMP" \
               "$EVENT" \
               "$NANVIX_VER" \
               "$FAILED_JOBS" \
-              "$RUN_URL"
+              "$RUN_URL" \
+              "$TEAM_CC"
             gh issue comment "$ISSUE_NUM" \
               --repo "$REPO" \
               --body "$COMMENT_BODY"
@@ -334,12 +349,17 @@ jobs:
             exit 0
           fi
 
-          printf -v BODY '## CI Workflow Failure\n\n**Repository:** %s\n**Branch:** %s\n\n### Occurrences\n\n%s\n%s\n%s' \
+          TEAM_CC=""
+          if [[ -n "$TEAM_SLUG" ]]; then
+            printf -v TEAM_CC '\n\ncc @%s/%s' "$ORG" "$TEAM_SLUG"
+          fi
+          printf -v BODY '## CI Workflow Failure\n\n**Repository:** %s\n**Branch:** %s\n\n### Occurrences\n\n%s\n%s\n%s%s' \
             "$REPO" \
             "${{ github.ref_name }}" \
             "$HEADER" \
             "$SEPARATOR" \
-            "$OCCURRENCE"
+            "$OCCURRENCE" \
+            "$TEAM_CC"
 
           ASSIGNEE_ARGS=()
           if [[ -n "$ADMINS" ]]; then


### PR DESCRIPTION
## Summary

- **Skip cancelled-run notifications:** The `report-failure` job now only triggers on true failures (`== 'failure'`), ignoring runs cancelled by higher-priority concurrency groups on the default branch. The `ci-passed` branch-protection gate still treats cancellation as failure (intentional).

- **Tag Admin team on failure issues:** Adds a configurable `failure-notify-team` input (default `admin`) that `@`-mentions the org team (`@<org>/<slug>`) in both new issue bodies and update comments, so all team members are notified.