### PR TITLE
fix(ci): pass GH_TOKEN to test steps

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -215,10 +215,14 @@ jobs:
 
       - name: Test
         if: ${{ !contains(fromJSON(inputs.skip-full-test-modes), matrix.process-mode) }}
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
         run: ./z test
 
       - name: Test (limited)
         if: ${{ contains(fromJSON(inputs.skip-full-test-modes), matrix.process-mode) }}
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
         run: ./z test -- ${{ inputs.standalone-test-args }}
 
       - name: Release
@@ -286,8 +290,8 @@ jobs:
           NANVIX_ZUTIL_VERSION: ${{ inputs.zutil-version }}
         shell: pwsh
         run: |
-          $wheel = gh api "repos/nanvix/zutils/releases/tags/$env:NANVIX_ZUTIL_VERSION" `
-            --jq '.assets[] | select(.name | endswith(\".whl\")) | .browser_download_url'
+          $jq = '.assets[] | select(.name | endswith(".whl")) | .browser_download_url'
+          $wheel = gh api "repos/nanvix/zutils/releases/tags/$env:NANVIX_ZUTIL_VERSION" --jq $jq
           python -m pip install $wheel
 
       - name: Setup (downloads Windows host binaries)


### PR DESCRIPTION
## Summary

The Test and Test (limited) steps in the reusable workflow were missing `GH_TOKEN` in their env block. When `./z test` makes GitHub API calls (e.g. to download sysroot binaries during standalone ramfs building), it runs unauthenticated and hits the 60 req/hr rate limit.

This caused nanvix/posix-tests#45 — the `hyperlight-multi-process` matrix cell failed with `GitHub API rate limit exceeded`.

## Fix

Pass `GH_TOKEN` to both test steps, matching the Setup step which already had it.