### PR TITLE
feat(ci): Add opt-in windows-build step to windows-test job

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -94,6 +94,16 @@ on:
         required: false
         default: true
         type: boolean
+      windows-build:
+        description: >
+          Run the consumer's build hook (nanvix-zutil build) on the
+          Windows runner before testing. Requires the consumer repo to
+          support cross-compilation on Windows via Docker (e.g. cpython).
+          When enabled, the build populates local artifacts so tests use
+          a freshly built binary instead of downloading a release.
+        required: false
+        default: false
+        type: boolean
     secrets:
       GH_TOKEN:
         description: >
@@ -299,6 +309,13 @@ jobs:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
         shell: pwsh
         run: nanvix-zutil setup
+
+      - name: Build (cross-compile via Docker)
+        if: inputs.windows-build
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        shell: pwsh
+        run: nanvix-zutil build
 
       - name: Test
         env:


### PR DESCRIPTION
## Summary

Add a `windows-build` input (boolean, default `false`) to the reusable CI workflow that runs `nanvix-zutil build` on the Windows runner before testing.

## Problem

The `windows-test` job currently only runs `setup` + `test`. On Windows, if no local build artifacts exist, the test stage downloads a pre-built binary from the latest GitHub release. When a backwards-incompatible ABI change occurs in nanvix (e.g. the `mmap` kcall signature change in v0.12.462), the stale release binary crashes on the new kernel.

This caused the cpython CI failure in nanvix/cpython#463 — Linux builds passed (fresh compilation), but Windows tests failed (downloaded binary built against old ABI).

## Solution

Consumer repos that support Docker-based cross-compilation on Windows (e.g. cpython via `.nanvix/docker.py`) can now opt in with:

```yaml
windows-build: true
```

This inserts a `nanvix-zutil build` step between `setup` and `test`, populating local build artifacts so tests always use a binary matching the current nanvix version.

## Changes

- Added `windows-build` input (boolean, default `false`)
- Added conditional Build step in `windows-test` job between Setup and Test

## Next Steps

Once this is tagged, update the cpython caller workflow to pass `windows-build: true`.