### PR TITLE
fix(ci): Switch Docker to Linux containers before Windows build

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -310,6 +310,13 @@ jobs:
         shell: pwsh
         run: nanvix-zutil setup
 
+      - name: Switch Docker to Linux containers
+        if: inputs.windows-build
+        shell: pwsh
+        run: |
+          & 'C:\Program Files\Docker\Docker\DockerCli.exe' -SwitchLinuxEngine
+          docker info
+
       - name: Build (cross-compile via Docker)
         if: inputs.windows-build
         env:


### PR DESCRIPTION
## Problem

The `Build (cross-compile via Docker)` step added in #53 fails on `windows-latest` runners with:

```
docker: image operating system "linux" cannot be used on this platform: operating system is not supported
```

The Docker daemon on Windows runners defaults to Windows container mode, but the cross-compilation toolchain image (`nanvix/toolchain:latest-minimal`) is a Linux image.

## Fix

Add a step that switches Docker to Linux container mode via `DockerCli.exe -SwitchLinuxEngine` before running the build. Also runs `docker info` to confirm the switch succeeded.

The step is conditional on `inputs.windows-build` so it only runs when the build is enabled.

## Related

- #53 — added the `windows-build` input
- nanvix/cpython#494 — first consumer using `windows-build: true` (currently failing)