### PR TITLE
Add nanvix-python to tiered CI cascade as Tier 4

### DIFF
--- a/.github/workflows/nanvix-update-workflows.yml
+++ b/.github/workflows/nanvix-update-workflows.yml
@@ -15,9 +15,10 @@ on:
       - "v*"
   schedule:
     # Tier-to-repo mapping lives in tier-config.json.
-    - cron: "0 9 * * *"   # Tier 1
-    - cron: "0 10 * * *"  # Tier 2
-    - cron: "0 11 * * *"  # Tier 3
+    - cron: "0 9 * * *" # Tier 1
+    - cron: "0 10 * * *" # Tier 2
+    - cron: "0 11 * * *" # Tier 3
+    - cron: "0 12 * * *" # Tier 4
   workflow_dispatch:
 
 permissions:
@@ -29,6 +30,7 @@ concurrency:
       github.event.schedule == '0 9 * * *' && 'tier1' ||
       github.event.schedule == '0 10 * * *' && 'tier2' ||
       github.event.schedule == '0 11 * * *' && 'tier3' ||
+      github.event.schedule == '0 12 * * *' && 'tier4' ||
       'all'
     }}
   cancel-in-progress: true

--- a/.github/workflows/nanvix-update-zutils.yml
+++ b/.github/workflows/nanvix-update-zutils.yml
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 # This workflow syncs consumer repositories with the latest nanvix/zutils
-# release. It runs on a tiered daily schedule (09:00/10:00/11:00 UTC) that
+# release. It runs on a tiered daily schedule (09:00/10:00/11:00/12:00 UTC) that
 # mirrors the consumer CI cascade, can be triggered manually via
 # workflow_dispatch, or called from another workflow (e.g. the zutils
 # release pipeline) via workflow_call with an explicit tag.
@@ -20,9 +20,10 @@ name: Update Zutils Version
 on:
   schedule:
     # Tier-to-repo mapping lives in tier-config.json.
-    - cron: "0 9 * * *"   # Tier 1
-    - cron: "0 10 * * *"  # Tier 2
-    - cron: "0 11 * * *"  # Tier 3
+    - cron: "0 9 * * *" # Tier 1
+    - cron: "0 10 * * *" # Tier 2
+    - cron: "0 11 * * *" # Tier 3
+    - cron: "0 12 * * *" # Tier 4
   workflow_dispatch:
   workflow_call:
     inputs:
@@ -44,6 +45,7 @@ concurrency:
       github.event.schedule == '0 9 * * *' && 'tier1' ||
       github.event.schedule == '0 10 * * *' && 'tier2' ||
       github.event.schedule == '0 11 * * *' && 'tier3' ||
+      github.event.schedule == '0 12 * * *' && 'tier4' ||
       'all'
     }}
   cancel-in-progress: true

--- a/consumer-repos.json
+++ b/consumer-repos.json
@@ -6,5 +6,6 @@
   "nanvix/openssl",
   "nanvix/cpython",
   "nanvix/quickjs",
-  "nanvix/posix-tests"
+  "nanvix/posix-tests",
+  "nanvix/nanvix-python"
 ]

--- a/tier-config.json
+++ b/tier-config.json
@@ -25,6 +25,13 @@
       "repos": [
         "nanvix/cpython"
       ]
+    },
+    {
+      "name": "tier4",
+      "cron": "0 12 * * *",
+      "repos": [
+        "nanvix/nanvix-python"
+      ]
     }
   ]
 }


### PR DESCRIPTION
Integrate nanvix/nanvix-python into the daily workflow update pipeline. This introduces a new Tier 4 scheduled at 12:00 UTC, running after Tiers 1–3 (09:00–11:00 UTC) to respect the dependency chain.

**Changes:**
- `consumer-repos.json`: add nanvix/nanvix-python to consumer list
- `tier-config.json`: define tier4 with cron `0 12 * * *`
- `nanvix-update-workflows.yml`: add tier4 schedule and concurrency group
- `nanvix-update-zutils.yml`: add tier4 schedule and concurrency group