### PR TITLE
fix: generate lint config files in CI

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -193,6 +193,33 @@ jobs:
           echo "${SHFMT_SHA256}  /tmp/shfmt" | sha256sum -c -
           sudo install -m 755 /tmp/shfmt /usr/local/bin/shfmt
 
+      - name: Generate lint configs
+        run: |
+          mkdir -p .nanvix
+          cat > .nanvix/black.toml << 'TOML'
+          [tool.black]
+          line-length = 88
+          target-version = ["py312"]
+          TOML
+          cat > .nanvix/.yamllint.yml << 'YAML'
+          extends: default
+          rules:
+            line-length:
+              max: 120
+            truthy:
+              check-keys: false
+            document-start: disable
+          YAML
+          cat > .nanvix/pyrightconfig.json << 'JSON'
+          {
+            "pythonVersion": "3.12",
+            "typeCheckingMode": "strict",
+            "include": ["."],
+            "venvPath": ".",
+            "venv": "venv"
+          }
+          JSON
+
       - name: Bootstrap .nanvix/venv with nanvix-zutil
         if: inputs.python-paths != ''
         env:


### PR DESCRIPTION
Config files (black.toml, .yamllint.yml, pyrightconfig.json) are gitignored in consumer repos — they're generated locally by nanvix-zutil. The format-and-lint job fails because these files don't exist in CI checkouts.

This adds a `Generate lint configs` step that creates the config files inline before the lint steps run.