### PR TITLE
fix: add yaml-paths input and scope yamllint to nanvix files only

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -132,6 +132,13 @@ on:
         required: false
         type: string
         default: "z z.sh"
+      yaml-paths:
+        description: >
+          Space-separated YAML file or directory paths to lint with yamllint.
+          Defaults to the nanvix-ci workflow file only.
+        required: false
+        type: string
+        default: ".github/workflows/nanvix-ci.yml"
     secrets:
       GH_TOKEN:
         description: >
@@ -249,7 +256,8 @@ jobs:
         run: shellcheck ${{ inputs.shell-paths }}
 
       - name: Lint YAML files (yamllint)
-        run: uvx yamllint@1.37.0 -c .nanvix/.yamllint.yml .github/workflows/
+        if: inputs.yaml-paths != ''
+        run: uvx yamllint@1.37.0 -c .nanvix/.yamllint.yml ${{ inputs.yaml-paths }}
 
   # -------------------------------------------------------------------
   # Job 1: Resolve Nanvix release metadata via nanvix-zutil


### PR DESCRIPTION
Consumer repos with upstream workflow files (cpython, quickjs, openssl, etc.) fail yamllint because those upstream files don't conform. Add a `yaml-paths` input defaulting to `nanvix-ci.yml` only.