### PR TITLE
Register nanvix/xz as tier1 consumer

### DIFF
--- a/consumer-repos.json
+++ b/consumer-repos.json
@@ -7,5 +7,6 @@
   "nanvix/cpython",
   "nanvix/quickjs",
   "nanvix/posix-tests",
-  "nanvix/nanvix-python"
+  "nanvix/nanvix-python",
+  "nanvix/xz"
 ]

--- a/tier-config.json
+++ b/tier-config.json
@@ -9,7 +9,8 @@
         "nanvix/openssl",
         "nanvix/quickjs",
         "nanvix/libffi",
-        "nanvix/posix-tests"
+        "nanvix/posix-tests",
+        "nanvix/xz"
       ]
     },
     {


### PR DESCRIPTION
# Register nanvix/xz as tier1 consumer

Adds `nanvix/xz` to the workflows registry so the daily tier1 cron (`0 9 * * *`) picks it up alongside the other zero-dep leaf libraries (zlib, bzip2, openssl, quickjs, libffi, posix-tests).

The xz port itself is already complete on `nanvix/xz` `feat/port-test-ci-release` — vendored autotools, `liblzma.{a,pc}` + headers, all six upstream C tests passing under `nanvixd.elf`, two release tags already pushed (`5.2.5-nanvix-0.12.485`, `5.2.5-nanvix-0.12.506`). It just needed to be wired into the rotation.

## Change

Append `nanvix/xz` to:
- `consumer-repos.json` (9 → 10 entries)
- `tier-config.json` `tier1.repos` (6 → 7 entries)

Order matches the `nanvix-python` precedent (`9c36ecd`): append, don't reorder. The validator in `scripts/select-tier-repos.sh` requires the two manifests to stay set-equal, so both files move in lockstep in a single commit.

No workflow YAML changes — adding to an existing tier doesn't touch the duplicated cron/concurrency blocks (those only need edits when introducing a new tier).

## Not included (intentional)

- **`downstream-dispatches` from xz → cpython.** Both zlib and sqlite omit this input entirely and neither has a `repository_dispatch` listener; xz follows that pattern. Until cpython grows a listener, dispatches would fire into the void. Cpython will pick up liblzma via its own daily tier3 cron once the cpython-side staging lands (see follow-ups).
- **cpython-side staging.** `.nanvix/nanvix.toml` `[dependencies]`, `.nanvix/z.py` `_DEP_EXPECTED_LIBS`, `.nanvix/config.py` link line, and the sysroot copy of `liblzma.{a,pc}` + headers all need adding before `_lzma` actually builds. Out of scope here; tracked as the next D3R cycle.

## Risk

Tier1 now has 7 repos firing at the same minute. Concurrency caps in the workflows themselves should absorb it; if rate-limit pressure shows up post-merge, remediation is a tier split, not a revert.
