### PR TITLE
Correct tier ordering for XML library dependencies

### DIFF
--- a/tier-config.json
+++ b/tier-config.json
@@ -10,8 +10,6 @@
         "nanvix/quickjs",
         "nanvix/libffi",
         "nanvix/libxml2",
-        "nanvix/libxslt",
-        "nanvix/lxml",
         "nanvix/posix-tests",
         "nanvix/xz"
       ]
@@ -20,6 +18,7 @@
       "name": "tier2",
       "cron": "0 10 * * *",
       "repos": [
+        "nanvix/libxslt",
         "nanvix/sqlite"
       ]
     },
@@ -27,6 +26,7 @@
       "name": "tier3",
       "cron": "0 11 * * *",
       "repos": [
+        "nanvix/lxml",
         "nanvix/cpython"
       ]
     },


### PR DESCRIPTION
libxslt depends on libxml2 and lxml depends on both. Moved them to respect build order:
- tier1: libxml2 (no deps)
- tier2: libxslt (requires libxml2)
- tier3: lxml (requires libxml2 + libxslt), cpython (requires libxml2 + sqlite)