### PR TITLE
fix: restructure tier grouping to respect dependency chain

### DIFF
--- a/.github/workflows/nanvix-update-workflows.yml
+++ b/.github/workflows/nanvix-update-workflows.yml
@@ -19,6 +19,8 @@ on:
     - cron: "0 10 * * *" # Tier 2
     - cron: "0 11 * * *" # Tier 3
     - cron: "0 12 * * *" # Tier 4
+    - cron: "0 13 * * *" # Tier 5
+    - cron: "0 14 * * *" # Tier 6
   workflow_dispatch:
 
 permissions:
@@ -31,6 +33,8 @@ concurrency:
       github.event.schedule == '0 10 * * *' && 'tier2' ||
       github.event.schedule == '0 11 * * *' && 'tier3' ||
       github.event.schedule == '0 12 * * *' && 'tier4' ||
+      github.event.schedule == '0 13 * * *' && 'tier5' ||
+      github.event.schedule == '0 14 * * *' && 'tier6' ||
       'all'
     }}
   cancel-in-progress: true

--- a/.github/workflows/nanvix-update-zutils.yml
+++ b/.github/workflows/nanvix-update-zutils.yml
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 # This workflow syncs consumer repositories with the latest nanvix/zutils
-# release. It runs on a tiered daily schedule (09:00/10:00/11:00/12:00 UTC) that
+# release. It runs on a tiered daily schedule (09:00–14:00 UTC) that
 # mirrors the consumer CI cascade, can be triggered manually via
 # workflow_dispatch, or called from another workflow (e.g. the zutils
 # release pipeline) via workflow_call with an explicit tag.
@@ -24,6 +24,8 @@ on:
     - cron: "0 10 * * *" # Tier 2
     - cron: "0 11 * * *" # Tier 3
     - cron: "0 12 * * *" # Tier 4
+    - cron: "0 13 * * *" # Tier 5
+    - cron: "0 14 * * *" # Tier 6
   workflow_dispatch:
   workflow_call:
     inputs:
@@ -46,6 +48,8 @@ concurrency:
       github.event.schedule == '0 10 * * *' && 'tier2' ||
       github.event.schedule == '0 11 * * *' && 'tier3' ||
       github.event.schedule == '0 12 * * *' && 'tier4' ||
+      github.event.schedule == '0 13 * * *' && 'tier5' ||
+      github.event.schedule == '0 14 * * *' && 'tier6' ||
       'all'
     }}
   cancel-in-progress: true

--- a/tier-config.json
+++ b/tier-config.json
@@ -9,7 +9,6 @@
         "nanvix/openssl",
         "nanvix/quickjs",
         "nanvix/libffi",
-        "nanvix/libxml2",
         "nanvix/posix-tests",
         "nanvix/xz"
       ]
@@ -18,7 +17,7 @@
       "name": "tier2",
       "cron": "0 10 * * *",
       "repos": [
-        "nanvix/libxslt",
+        "nanvix/libxml2",
         "nanvix/sqlite"
       ]
     },
@@ -26,13 +25,26 @@
       "name": "tier3",
       "cron": "0 11 * * *",
       "repos": [
-        "nanvix/lxml",
-        "nanvix/cpython"
+        "nanvix/libxslt"
       ]
     },
     {
       "name": "tier4",
       "cron": "0 12 * * *",
+      "repos": [
+        "nanvix/lxml"
+      ]
+    },
+    {
+      "name": "tier5",
+      "cron": "0 13 * * *",
+      "repos": [
+        "nanvix/cpython"
+      ]
+    },
+    {
+      "name": "tier6",
+      "cron": "0 14 * * *",
       "repos": [
         "nanvix/nanvix-python"
       ]


### PR DESCRIPTION
## Summary

Restructure CI tier grouping so that each package builds strictly after its dependencies.

### Problem

- `libxml2` was in tier1 alongside its dependency `zlib`
- `cpython` was in tier3 alongside its dependency `lxml`

### Changes

| Tier | Repos | Depends on |
|------|-------|------------|
| 1 | zlib, bzip2, openssl, quickjs, libffi, posix-tests, xz | (base) |
| 2 | libxml2, sqlite | tier1 |
| 3 | libxslt | tier2 |
| 4 | lxml | tier3 |
| 5 | cpython | tier4 |
| 6 | nanvix-python | tier5 |

Also adds tier5/tier6 cron triggers (`0 13 * * *` / `0 14 * * *`) to both `nanvix-update-zutils.yml` and `nanvix-update-workflows.yml`.