### PR TITLE
ci: pass docker-image input to nanvix-zutil setup

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -346,7 +346,7 @@ jobs:
       - name: Setup (with Docker)
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
-        run: nanvix-zutil setup --with-docker
+        run: nanvix-zutil setup --with-docker ${{ inputs.docker-image }}
 
       - name: Build (in Docker)
         run: nanvix-zutil build


### PR DESCRIPTION
The `--with-docker` flag needs the image name so `nanvix-zutil` uses the correct image instead of its hardcoded default (`nanvix/toolchain:latest-minimal`).

Without this, `nanvix-zutil setup --with-docker` fails because it looks for the old Docker Hub image even though the CI already pulled the new GHCR image.