### PR TITLE
ci: export NANVIX_DOCKER_IMAGE as job-level env var

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -320,6 +320,7 @@ jobs:
       NANVIX_DEPLOYMENT_MODE: ${{ matrix.process-mode }}
       NANVIX_MEMORY_SIZE: ${{ matrix.memory }}
       NANVIX_VERSION: ${{ needs.get-nanvix-info.outputs.nanvix_tag }}
+      NANVIX_DOCKER_IMAGE: ${{ inputs.docker-image }}
     steps:
       - uses: actions/checkout@v6
 
@@ -430,6 +431,7 @@ jobs:
       NANVIX_DEPLOYMENT_MODE: standalone
       NANVIX_MEMORY_SIZE: ${{ matrix.memory }}
       NANVIX_VERSION: ${{ needs.get-nanvix-info.outputs.nanvix_tag }}
+      NANVIX_DOCKER_IMAGE: ${{ inputs.docker-image }}
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
Makefiles use `?=` for `NANVIX_DOCKER_IMAGE`, which reads from the environment. Export the `docker-image` input as `NANVIX_DOCKER_IMAGE` in both Linux build and Windows test job-level env blocks so that repos that haven't yet updated their Makefile default still use the correct image.