### PR TITLE
[ci] Make docker-image a required input

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -142,10 +142,8 @@ on:
       docker-image:
         description: >
           Docker image used for cross-compilation.
-          Defaults to the Nanvix GCC toolchain image on GHCR.
-        required: false
+        required: true
         type: string
-        default: "ghcr.io/nanvix/toolchain-gcc:sha-34a3641"
     secrets:
       GH_TOKEN:
         description: >
@@ -450,7 +448,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
         shell: pwsh
-        run: nanvix-zutil setup
+        run: nanvix-zutil setup --with-docker ${{ inputs.docker-image }}
 
       - name: Download Linux build output
         if: ${{ !inputs.windows-build }}

--- a/.github/workflows/test-nanvix-ci.yml
+++ b/.github/workflows/test-nanvix-ci.yml
@@ -39,6 +39,7 @@ jobs:
       platforms: ${{ inputs.platforms }}
       process-modes: ${{ inputs.process-modes }}
       caller-event-name: ${{ github.event_name }}
+      docker-image: "ghcr.io/nanvix/toolchain-gcc:sha-34a3641"
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
       DISPATCH_TOKEN: ${{ secrets.DISPATCH_TOKEN }}


### PR DESCRIPTION
## Summary

- Make `docker-image` a required input with no default in `nanvix-ci.yml` (breaking change — callers must supply it explicitly).
- Add `--with-docker` to the Windows setup step (required by zutils v0.8.1).
- Update `test-nanvix-ci.yml` to pass `docker-image` explicitly.

## Breaking Change

Consumer repos must add `docker-image: "ghcr.io/nanvix/toolchain-gcc:sha-34a3641"` (or their desired image) to their caller workflow's `with:` block.