### PR TITLE
ci: authenticate to GHCR and retry docker pull

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -354,10 +354,10 @@ jobs:
         run: |
           set -euo pipefail
           for attempt in 1 2 3 4 5; do
+            echo "attempting docker pull (attempt $attempt/5)" >&2
             if docker pull "$NANVIX_DOCKER_IMAGE"; then
               exit 0
             fi
-            echo "docker pull failed (attempt $attempt/5); retrying..." >&2
             sleep $((attempt * 10))
           done
           echo "docker pull failed after 5 attempts" >&2
@@ -499,9 +499,9 @@ jobs:
           NANVIX_DOCKER_IMAGE: ${{ inputs.docker-image }}
         run: |
           for ($attempt = 1; $attempt -le 5; $attempt++) {
+            Write-Host "attempting docker pull (attempt $attempt/5)"
             docker pull $env:NANVIX_DOCKER_IMAGE
             if ($LASTEXITCODE -eq 0) { exit 0 }
-            Write-Host "docker pull failed (attempt $attempt/5); retrying..."
             Start-Sleep -Seconds ($attempt * 10)
           }
           Write-Host "docker pull failed after 5 attempts"

--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -179,6 +179,7 @@ permissions:
   actions: write
   issues: write
   pull-requests: write
+  packages: read
 
 jobs:
   # -------------------------------------------------------------------
@@ -339,8 +340,28 @@ jobs:
             --jq '.assets[] | select(.name | endswith(".whl")) | .browser_download_url')
           python3 -m pip install --break-system-packages "$WHEEL_URL"
 
+      - name: Log in to GHCR
+        if: startsWith(inputs.docker-image, 'ghcr.io/')
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Pull Docker image
-        run: docker pull ${{ inputs.docker-image }}
+        env:
+          NANVIX_DOCKER_IMAGE: ${{ inputs.docker-image }}
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3 4 5; do
+            if docker pull "$NANVIX_DOCKER_IMAGE"; then
+              exit 0
+            fi
+            echo "docker pull failed (attempt $attempt/5); retrying..." >&2
+            sleep $((attempt * 10))
+          done
+          echo "docker pull failed after 5 attempts" >&2
+          exit 1
 
       - name: Setup (with Docker)
         env:
@@ -463,10 +484,28 @@ jobs:
           & 'C:\Program Files\Docker\Docker\DockerCli.exe' -SwitchLinuxEngine
           docker info
 
+      - name: Log in to GHCR
+        if: inputs.windows-build && startsWith(inputs.docker-image, 'ghcr.io/')
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Pull Docker image
         if: inputs.windows-build
         shell: pwsh
-        run: docker pull ${{ inputs.docker-image }}
+        env:
+          NANVIX_DOCKER_IMAGE: ${{ inputs.docker-image }}
+        run: |
+          for ($attempt = 1; $attempt -le 5; $attempt++) {
+            docker pull $env:NANVIX_DOCKER_IMAGE
+            if ($LASTEXITCODE -eq 0) { exit 0 }
+            Write-Host "docker pull failed (attempt $attempt/5); retrying..."
+            Start-Sleep -Seconds ($attempt * 10)
+          }
+          Write-Host "docker pull failed after 5 attempts"
+          exit 1
 
       - name: Build (cross-compile via Docker)
         if: inputs.windows-build


### PR DESCRIPTION
## Problem

Transient `ghcr.io` HTTPS timeouts have been sinking otherwise-healthy CI runs on consumer repos. Example: [nanvix/posix-tests run 25812391627](https://github.com/nanvix/posix-tests/actions/runs/25812391627/job/75831907990?pr=119), where the `Pull Docker image` step failed with:

```
Error response from daemon: Get "https://ghcr.io/v2/":
  context deadline exceeded (Client.Timeout exceeded while awaiting headers)
```

The image is digest-pinned and other PRs against the same digest succeeded around the same time, so this is a network/registry flake — not auth, not a missing image, not rate limiting. But `docker pull` was run exactly once with no retry, so a single ~15s timeout failed the whole job.

## Fix

In `.github/workflows/nanvix-ci.yml`, for both the Linux `build` job and the Windows `windows-test` job:

1. **Authenticate to GHCR** with `docker/login-action@v3` using `GITHUB_TOKEN`, gated on `startsWith(inputs.docker-image, 'ghcr.io/')` so non-GHCR images keep working without auth. Adds `packages: read` to the reusable workflow's top-level `permissions`.
2. **Retry `docker pull`** up to 5 times with linear backoff (10/20/30/40s). Bash loop on Linux, pwsh loop (using `$LASTEXITCODE`) on Windows.

## Notes for reviewers

- `secrets.GITHUB_TOKEN` and `github.actor` are automatically forwarded into reusable workflows, so consumers don't need to pass anything new.
- Consumers that grant this workflow `permissions:` explicitly (rather than inheriting) will need `packages: read` added on their side.
- This fix only takes effect once consumers bump their workflow ref to a new tag. (You said you'll cut the bump once this merges.)