### PR TITLE
Include shared libraries in Windows test artifacts

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -398,13 +398,14 @@ jobs:
             dist/*.zip
           retention-days: 7
 
-      - name: Upload ELF binaries for Windows test
+      - name: Upload build binaries for Windows test
         if: success() && inputs.windows-test && matrix.process-mode == 'standalone'
         uses: actions/upload-artifact@v7
         with:
           name: windows-test-build-${{ matrix.platform }}-${{ matrix.memory }}
           path: |
             **/*.elf
+            **/*.so
           retention-days: 1
           if-no-files-found: warn
 


### PR DESCRIPTION
## Summary

The Windows test artifact upload only included `**/*.elf` files. Tests that depend on shared libraries (e.g. `dlfcn-c` with `libmul.so`) fail on the Windows runner because the `.so` files are missing from the downloaded artifact.

## Fix

Add `**/*.so` to the upload glob in the Windows test artifact step so shared libraries are transferred alongside ELF binaries.

## Related

- nanvix/posix-tests#142 — Enable `dlfcn-c` test suite in standalone mode