### PR TITLE
Include static libs and public headers in windows-test artifact

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -431,6 +431,8 @@ jobs:
           path: |
             **/*.elf
             **/*.so
+            **/*.a
+            include/**/*.h
           retention-days: 1
           if-no-files-found: warn
 


### PR DESCRIPTION
## Summary

The `windows-test` job currently downloads only `**/*.elf` and `**/*.so` from the Linux build''s `windows-test-build-*` artifact. Consumer repos whose Windows test phase wants to validate the build output beyond just booting an ELF (e.g. smoke tests that inspect static libraries, or integration tests that check generated public headers) cannot run those phases in CI because the artefacts are absent.

In `nanvix/openssl` PR #230, the consumer''s `./z test` had to be downgraded on Windows to functional-only because `libcrypto.a` / `libssl.a` / `include/openssl/*.h` aren''t part of the Windows artifact, even though they are produced by the Linux build.

## Changes

`.github/workflows/nanvix-ci.yml`: expand the `Upload build binaries for Windows test` step''s globs to additionally include:

- `**/*.a` — static libraries.
- `include/**/*.h` — public headers.

```yaml
path: |
  **/*.elf
  **/*.so
  **/*.a
  include/**/*.h
```

## Impact

- **Additive**: `upload-artifact` skips missing matches, and `if-no-files-found: warn` is preserved, so consumers that don''t produce static libs or `include/` headers see no change.
- **`nanvix/openssl`**: unlocks running the full smoke + integration + functional pipeline on Windows CI (instead of functional-only).
- **Other consumers** (`zlib`, `bzip2`, etc.): no regression. They benefit if they later add smoke/integration phases on Windows.

## Test plan

- Smoke-validate downstream in `nanvix/openssl` after bumping the pin from `v2.0.2` to a new release of this branch.