### PR TITLE
fix: update zutils version regex

### DIFF
--- a/.github/workflows/nanvix-update-zutils.yml
+++ b/.github/workflows/nanvix-update-zutils.yml
@@ -175,8 +175,12 @@ jobs:
             local FILE
             for FILE in .github/workflows/*.yml .github/workflows/*.yaml; do
               [ -f "$FILE" ] || continue
-              if grep -qE 'zutil-version:[[:space:]]*"v[^"]+"' "$FILE"; then
+              # Update the `zutil-version:` input on reusable-workflow
+              # calls, as well as `NANVIX_ZUTIL_VERSION:` env vars used
+              # by custom jobs that install nanvix-zutil directly.
+              if grep -qE '(zutil-version|NANVIX_ZUTIL_VERSION):[[:space:]]*"v[^"]+"' "$FILE"; then
                 sed -i -E "s|(zutil-version:[[:space:]]*\")v[^\"]+|\1${LATEST_TAG}|g" "$FILE"
+                sed -i -E "s|(NANVIX_ZUTIL_VERSION:[[:space:]]*\")v[^\"]+|\1${LATEST_TAG}|g" "$FILE"
                 if ! git diff --quiet -- "$FILE"; then
                   git add "$FILE"
                   CHANGED=1

--- a/.github/workflows/nanvix-update-zutils.yml
+++ b/.github/workflows/nanvix-update-zutils.yml
@@ -178,9 +178,9 @@ jobs:
               # Update the `zutil-version:` input on reusable-workflow
               # calls, as well as `NANVIX_ZUTIL_VERSION:` env vars used
               # by custom jobs that install nanvix-zutil directly.
-              if grep -qE '(zutil-version|NANVIX_ZUTIL_VERSION):[[:space:]]*"v[^"]+"' "$FILE"; then
-                sed -i -E "s|(zutil-version:[[:space:]]*\")v[^\"]+|\1${LATEST_TAG}|g" "$FILE"
-                sed -i -E "s|(NANVIX_ZUTIL_VERSION:[[:space:]]*\")v[^\"]+|\1${LATEST_TAG}|g" "$FILE"
+              if grep -qE '(zutil-version|NANVIX_ZUTIL_VERSION):[[:space:]]*['"'"'"]?v[^[:space:]'"'"'"]+['"'"'"]?' "$FILE"; then
+                sed -i -E "s|(zutil-version:[[:space:]]*)(['\"]?)v[^[:space:]'\"]+\2|\1\2${LATEST_TAG}\2|g" "$FILE"
+                sed -i -E "s|(NANVIX_ZUTIL_VERSION:[[:space:]]*)(['\"]?)v[^[:space:]'\"]+\2|\1\2${LATEST_TAG}\2|g" "$FILE"
                 if ! git diff --quiet -- "$FILE"; then
                   git add "$FILE"
                   CHANGED=1


### PR DESCRIPTION
## What

Updates the caller-workflow update step in `nanvix-update-zutils.yml`

## Why 

[CI is failing for nanvix/nanvix-python](https://github.com/nanvix/nanvix-python/actions/runs/26467020565/job/77930463214?pr=223) due to an outdated nanvix-zutils version pin. This is occuring because the regex used to find the version is too narrow. nanvix-python uses an inline `NANVIX_ZUTIL_VERSION` environment variable as its pin instead of a job input parameter.

## Notes
- The custom job is forked from the `windows-test` reusable. It cannot be removed.
- `NANVIX_ZUTIL_VERSION` is used to directly fetch the zutils wheel, but this environment variable is _also_ used to set the version when bootstrapping is used. 