### PR TITLE
fix: windows-release patterns against real assets

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -1017,8 +1017,8 @@ jobs:
           set -euo pipefail
           gh release download "$RELEASE_TAG" \
             --repo "${{ github.repository }}" \
-            --pattern "${PACKAGE_NAME}-${PACKAGE_VERSION}-*-standalone-*.tar.gz" \
-            --pattern "${PACKAGE_NAME}-${PACKAGE_VERSION}-*-standalone-*.tar.bz2" \
+            --pattern "*-standalone-*.tar.gz" \
+            --pattern "*-standalone-*.tar.bz2" \
             --dir release-download
           ls -la release-download/
 
@@ -1052,12 +1052,15 @@ jobs:
             DIST_DIR=$(find "$WORK" -mindepth 1 -maxdepth 1 -type d | head -1)
             DIR_NAME=$(basename "$DIST_DIR")
 
-            # Derive matrix suffix (e.g. x86-microvm-standalone-256mb)
-            # by stripping the ${PACKAGE_NAME}-${PACKAGE_VERSION}- prefix.
-            SUFFIX=${DIR_NAME#"${PACKAGE_NAME}-${PACKAGE_VERSION}-"}
-            WINZIP=$(find nanvix-windows -name "nanvix-windows-${SUFFIX}*.zip" | head -1)
+            # DIR_NAME is [<pkg>-]<platform>-standalone-<memsize>. Extract
+            # the join key components; the upstream windows zip carries
+            # extra tokens (arch prefix, -release- infix, sha suffix) so
+            # glob loosely around each.
+            MEMORY=${DIR_NAME##*-standalone-}
+            PLATFORM=${DIR_NAME%-standalone-*}; PLATFORM=${PLATFORM##*-}
+            WINZIP=$(find nanvix-windows -name "nanvix-windows-*${PLATFORM}-standalone-*${MEMORY}*.zip" | head -1)
             if [ -z "$WINZIP" ]; then
-              echo "::warning::No matching nanvix-windows zip for $SUFFIX; skipping"
+              echo "::warning::No matching nanvix-windows zip for ${PLATFORM}-${MEMORY}; skipping"
               echo "::endgroup::"
               continue
             fi


### PR DESCRIPTION
The download pattern and windows-zip lookup assumed a `${PACKAGE_NAME}-${PACKAGE_VERSION}-` filename prefix that no downstream actually produces (real assets: `microvm-standalone-256mb.tar.gz`, `zlib-microvm-standalone-256mb.tar.gz`, etc.). The download step matched zero files against every real caller; the `SUFFIX` strip was a no-op that fed a wrong glob to `find`.

- Download: drop the prefix, use `*-standalone-*.tar.{gz,bz2}`. Genuinely matches only standalone tarballs on real releases — excludes multi/single-process, .zip siblings, nanvix.lock.
- Repackage: extract PLATFORM / MEMORY directly from `DIR_NAME` via shell parameter expansion; glob loosely against the upstream windows zip which carries extra tokens (arch prefix, `-release-` infix, sha suffix).

Verified end-to-end against `nanvix/nanvix-python@3.12.3-nanvix-0.17.9-e1cdaf3` + `nanvix/nanvix@v0.19.9`. Output zip layout (`microvm-standalone-256mb/bin/nanvixd.exe` + `kernel.elf`, wrapper preserved) matches what `microsoft/mxc` pins in `versions.json` and `ARCHIVE_PREFIX`.

actionlint + shellcheck clean.

Known scope gap: the broad glob ignores `inputs.platforms`/`inputs.memory-sizes` filtering — repackages every standalone tarball on the release. Fine for nanvix-python (single tuple today); revisit if a downstream ever wants to publish more than it repackages.