### PR TITLE
[publisher] F: Preserve artifact path after clone

### DIFF
--- a/.github/workflows/lint-workflows.yml
+++ b/.github/workflows/lint-workflows.yml
@@ -8,10 +8,18 @@ name: Lint Workflows
 on:
   push:
     branches: ["main"]
-    paths: [".github/workflows/**"]
+    paths:
+      - ".github/workflows/**"
+      - "consumer-registry.json"
+      - "scripts/**"
+      - "tests/**"
   pull_request:
     branches: ["main"]
-    paths: [".github/workflows/**"]
+    paths:
+      - ".github/workflows/**"
+      - "consumer-registry.json"
+      - "scripts/**"
+      - "tests/**"
 
 jobs:
   actionlint:

--- a/scripts/publish-update.sh
+++ b/scripts/publish-update.sh
@@ -11,9 +11,15 @@ TITLE="${PR_TITLE:?PR_TITLE is required}"
 BODY="${PR_BODY:?PR_BODY is required}"
 EXPECTED_DIGEST="${EXPECTED_PATCH_SHA256:?EXPECTED_PATCH_SHA256 is required}"
 EXPECTED_BUNDLE_DIGEST="${EXPECTED_BUNDLE_SHA256:?EXPECTED_BUNDLE_SHA256 is required}"
-ARTIFACT_DIR="${ARTIFACT_DIR:?ARTIFACT_DIR is required}"
+ARTIFACT_INPUT="${ARTIFACT_DIR:?ARTIFACT_DIR is required}"
 TOKEN="${GH_TOKEN:?GH_TOKEN is required}"
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+if [ ! -d "$ARTIFACT_INPUT" ] || [ -L "$ARTIFACT_INPUT" ]; then
+    echo "error: publication artifact directory is missing or unsafe" >&2
+    exit 1
+fi
+ARTIFACT_DIR="$(cd "$ARTIFACT_INPUT" && pwd -P)"
 
 case "$KIND" in
     nanvix)

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 WORK="$ROOT/tests/.work"
 PASS=0
+cd "$ROOT"
 
 cleanup() {
     rm -rf "$WORK"
@@ -206,6 +207,7 @@ bundle_digest="$(
         sha256sum "$WORK/artifact/$name" | awk -v name="$name" '{print $1, name}'
     done | sha256sum | awk '{print $1}'
 )"
+artifact_relative="${WORK#"$ROOT"/}/artifact"
 TARGET_REPO=nanvix/zlib \
     UPDATE_KIND=nanvix \
     UPDATE_BRANCH=automation/update-nanvix-version \
@@ -213,7 +215,7 @@ TARGET_REPO=nanvix/zlib \
     PR_BODY="test update" \
     EXPECTED_BUNDLE_SHA256="$bundle_digest" \
     EXPECTED_PATCH_SHA256="$digest" \
-    ARTIFACT_DIR="$WORK/artifact" \
+    ARTIFACT_DIR="$artifact_relative" \
     GH_TOKEN=test \
     PUBLISH_CLONE_URL="$WORK/consumer" \
     PUBLISH_WORKDIR="$WORK/published" \


### PR DESCRIPTION
## Summary
Canonicalize and validate the publication artifact directory before changing into the fresh consumer clone.

The first v0.15.0 rollout proved that workflow-provided artifact paths are relative. Pre-clone digest/policy checks succeeded, but the stale-base check could no longer read `metadata.json` after `cd`, so every independent publisher failed closed. The regression test now runs the successful publisher path with a relative artifact directory.

## Validation
- 13 foundation tests
- ShellCheck
- shfmt