### PR TITLE
[updater] F: Confine SDK contracts to clones

### DIFF
--- a/.github/workflows/nanvix-update-nanvix.yml
+++ b/.github/workflows/nanvix-update-nanvix.yml
@@ -126,6 +126,7 @@ jobs:
               echo "::endgroup::"
               continue
             fi
+            cp sdk-release.json "$clone/.git/sdk-release.json"
 
             output="$GITHUB_WORKSPACE/mutation/$slug.output"
             : > "$output"
@@ -133,7 +134,7 @@ jobs:
               cd "$clone"
               GITHUB_OUTPUT="$output" \
                 UPDATE_KIND=nanvix \
-                UPDATE_TARGET="$GITHUB_WORKSPACE/sdk-release.json" \
+                UPDATE_TARGET=.git/sdk-release.json \
                 TARGET_REPO="$repo" \
                 ARTIFACT_DIR="$GITHUB_WORKSPACE/publication/$slug" \
                 "$GITHUB_WORKSPACE/scripts/create-update-artifact.sh"

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -313,4 +313,10 @@ grep -q 'types: \[nanvix-sdk-released\]' \
     "$ROOT/.github/workflows/nanvix-update-nanvix.yml")" -eq 1 ]
 ok "schedule and SDK dispatch share one verified tuple resolver"
 
+grep -Fq "cp sdk-release.json \"\$clone/.git/sdk-release.json\"" \
+    "$ROOT/.github/workflows/nanvix-update-nanvix.yml"
+grep -Fq 'UPDATE_TARGET=.git/sdk-release.json' \
+    "$ROOT/.github/workflows/nanvix-update-nanvix.yml"
+ok "SDK contracts remain confined to each read-only consumer clone"
+
 echo "1..$PASS"


### PR DESCRIPTION
## Summary
Place the verified `sdk-release.json` inside each credential-free consumer clone's Git metadata before invoking `update-nanvix`.

The first strict cascade correctly failed because zutils rejects local contract paths outside the target root. `.git/sdk-release.json` satisfies confinement without introducing an untracked worktree path or expanding the publication allowlist.

## Validation
- 14 workflow foundation tests
- ShellCheck and shfmt
- Actionlint v1.7.11