### PR TITLE
windows-release: exclude -dev archives from Windows repackaging

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -1204,6 +1204,10 @@ jobs:
             --pattern "*-standalone-*.tar.gz" \
             --pattern "*-standalone-*.tar.bz2" \
             --dir release-download
+          # Exclude -dev archives (headers/libs for downstream builds);
+          # only end-user archives get repackaged for Windows.
+          # See https://github.com/nanvix/zutils/issues/287.
+          find release-download -maxdepth 1 -name '*-dev.tar.*' -delete
           ls -la release-download/
 
       - name: Download Nanvix Windows binaries


### PR DESCRIPTION
# windows-release: exclude -dev archives from Windows repackaging

## What

The `windows-release` job in `.github/workflows/nanvix-ci.yml` downloads
`*-standalone-*.tar.{gz,bz2}` from a release and repackages them for
Windows (swap `bin/nanvixd.elf` → `bin/nanvixd.exe`, add `kernel.elf`,
re-zip).

After the `-dev` / no-suffix schema lands downstream (see
https://github.com/nanvix/zutils/issues/287, tracked in the zutils PRs
#307, #312, #313, #308), the glob will also match consumer-facing
`-dev` archives. Those contain headers and static libs, not
`bin/nanvixd.elf`, so the swap step would fail or produce a corrupt
zip.

This PR adds a one-liner post-download prune:

```sh
find release-download -maxdepth 1 -name '*-dev.tar.*' -delete
```

`gh release download` has no negative-pattern support, so filtering
after the fact is the KISS move.

## Why not tighten the download pattern?

The current pattern uses `*-standalone-*` which is intentionally loose
against filename evolution. Adding an exact-shape pattern (e.g.
`*-standalone-*mb.tar.gz`) would couple this workflow to today's
`memory_size` token being the last component, which is fragile against
future schema tweaks. A post-download filter keeps the download loose
and the exclusion explicit.

## Blocking

Ideally lands **after** https://github.com/nanvix/zutils/pull/312 so the
exclusion doesn't fire prematurely (currently there are no `-dev`
archives to prune, so this is a no-op on today's releases — safe to
land at any time, but semantically belongs alongside #312).

## Not in this PR

- The pre-existing `DIR_NAME=${DIR_NAME##*-standalone-}` parsing in the
  repackaging step looks brittle to me on close read (it depends on the
  tarball having a top-level directory shaped like
  `<pkg>-<platform>-standalone-<mem>`, which isn't what
  `nanvix-zutil release` produces today — archives are contents-flat).
  Either this is a latent bug or consumers pre-wrap their staging
  content. Out of scope; flagging for a separate look.
