### PR TITLE
[ci] Dispatch renamed distro from final SDK tier

### DIFF
--- a/.github/workflows/nanvix-update-nanvix.yml
+++ b/.github/workflows/nanvix-update-nanvix.yml
@@ -81,6 +81,7 @@ jobs:
     outputs:
       artifact_paths: ${{ steps.mutate.outputs.artifact_paths }}
       bundle_digests: ${{ steps.mutate.outputs.bundle_digests }}
+      distro_candidate: ${{ steps.mutate.outputs.distro_candidate }}
       failed: ${{ steps.mutate.outputs.failed }}
       patch_digests: ${{ steps.mutate.outputs.patch_digests }}
       publication_repos: ${{ steps.mutate.outputs.publication_repos }}
@@ -115,6 +116,7 @@ jobs:
           paths='{}'
           publications='[]'
           failed='[]'
+          distro_candidate=false
 
           while IFS= read -r repo; do
             slug="${repo//\//--}"
@@ -162,6 +164,9 @@ jobs:
                   echo "::warning::$repo returned no mutation status"
                   ;;
               esac
+              if [[ "$repo" == "nanvix/nanvix-python" && "$status" =~ ^(updated|current)$ ]]; then
+                distro_candidate=true
+              fi
             else
               failed=$(jq -c --arg repo "$repo" '. + [$repo]' <<< "$failed")
               echo "::warning::Mutation failed for $repo"
@@ -175,6 +180,7 @@ jobs:
             echo "bundle_digests=$bundle_digests"
             echo "artifact_paths=$paths"
             echo "publication_repos=$publications"
+            echo "distro_candidate=$distro_candidate"
             echo "failed=$failed"
           } >> "$GITHUB_OUTPUT"
 
@@ -230,6 +236,27 @@ jobs:
     secrets:
       app-private-key: ${{ secrets.CONSUMER_UPDATE_APP_PRIVATE_KEY }}
       dispatch-token: ${{ secrets.DISPATCH_TOKEN }}
+
+  dispatch-distro:
+    needs: [prepare, mutate, publish]
+    if: >-
+      always()
+      && needs.prepare.outputs.tier == 'tier6'
+      && needs.mutate.result == 'success'
+      && needs.mutate.outputs.distro_candidate == 'true'
+      && (needs.publish.result == 'success' || needs.publish.result == 'skipped')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch coherent distro release candidate
+        env:
+          GH_TOKEN: ${{ secrets.DISPATCH_TOKEN }}
+          SDK_VERSION: ${{ needs.prepare.outputs.sdk_version }}
+        run: |
+          jq -n --arg sdk_version "$SDK_VERSION" \
+            '{event_type: "distro-release-candidate", client_payload: {sdk_version: $sdk_version}}' |
+            gh api repos/nanvix/nanvix-distro/dispatches \
+              --method POST \
+              --input -
 
   report:
     needs: [mutate, publish]

--- a/.github/workflows/nanvix-update-nanvix.yml
+++ b/.github/workflows/nanvix-update-nanvix.yml
@@ -255,7 +255,7 @@ jobs:
         run: |
           jq -n --arg sdk_version "$SDK_VERSION" \
             '{event_type: "distro-release-candidate", client_payload: {sdk_version: $sdk_version}}' |
-            gh api repos/nanvix/nanvix-distro/dispatches \
+            gh api repos/nanvix/distro/dispatches \
               --method POST \
               --input -
 

--- a/.github/workflows/nanvix-update-nanvix.yml
+++ b/.github/workflows/nanvix-update-nanvix.yml
@@ -243,6 +243,7 @@ jobs:
       always()
       && needs.prepare.outputs.tier == 'tier6'
       && needs.mutate.result == 'success'
+      && needs.mutate.outputs.failed == '[]'
       && needs.mutate.outputs.distro_candidate == 'true'
       && (needs.publish.result == 'success' || needs.publish.result == 'skipped')
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ validates the registry and derives schedule or dispatch selections from it.
 The six cron entries in each updater workflow mirror the registry's tier
 offsets. `tests/run-tests.sh` rejects drift between those tuples.
 
+The final Nanvix update tier contains `nanvix-python`. When that consumer is
+current or has a publishable update, the tier dispatches the exact verified SDK
+version to `nanvix-distro`. The distro independently preflights its complete
+release set, so blocked final-tier updates do not advertise readiness and a
+premature candidate remains a safe deferred no-op.
+
 ## Secure consumer updates
 
 `nanvix-update-nanvix.yml` and `nanvix-update-zutils.yml` share this boundary:

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ offsets. `tests/run-tests.sh` rejects drift between those tuples.
 
 The final Nanvix update tier contains `nanvix-python`. When that consumer is
 current or has a publishable update, the tier dispatches the exact verified SDK
-version to `nanvix-distro`. The distro independently preflights its complete
+version to `nanvix/distro`. The distro independently preflights its complete
 release set, so blocked final-tier updates do not advertise readiness and a
 premature candidate remains a safe deferred no-op.
 

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -328,7 +328,7 @@ grep -Fq "needs.prepare.outputs.tier == 'tier6'" "$nanvix_update"
 grep -Fq "needs.mutate.outputs.distro_candidate == 'true'" "$nanvix_update"
 grep -Fq "needs.publish.result == 'success' || needs.publish.result == 'skipped'" \
     "$nanvix_update"
-grep -Fq 'repos/nanvix/nanvix-distro/dispatches' "$nanvix_update"
+grep -Fq 'repos/nanvix/distro/dispatches' "$nanvix_update"
 grep -Fq "client_payload: {sdk_version: \$sdk_version}" "$nanvix_update"
 ok "ready final-tier updates dispatch the exact SDK to the distro"
 

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -319,6 +319,19 @@ grep -Fq 'UPDATE_TARGET=.git/sdk-release.json' \
     "$ROOT/.github/workflows/nanvix-update-nanvix.yml"
 ok "SDK contracts remain confined to each read-only consumer clone"
 
+nanvix_update="$ROOT/.github/workflows/nanvix-update-nanvix.yml"
+grep -Fq "distro_candidate: \${{ steps.mutate.outputs.distro_candidate }}" \
+    "$nanvix_update"
+grep -Fq "\"nanvix/nanvix-python\" && \"\$status\" =~ ^(updated|current)\$" \
+    "$nanvix_update"
+grep -Fq "needs.prepare.outputs.tier == 'tier6'" "$nanvix_update"
+grep -Fq "needs.mutate.outputs.distro_candidate == 'true'" "$nanvix_update"
+grep -Fq "needs.publish.result == 'success' || needs.publish.result == 'skipped'" \
+    "$nanvix_update"
+grep -Fq 'repos/nanvix/nanvix-distro/dispatches' "$nanvix_update"
+grep -Fq "client_payload: {sdk_version: \$sdk_version}" "$nanvix_update"
+ok "ready final-tier updates dispatch the exact SDK to the distro"
+
 grep -Fq "jq -S 'del(.source_commit)' sdk-provenance.json" \
     "$ROOT/.github/workflows/nanvix-ci.yml"
 grep -Fq "release_published=false" \


### PR DESCRIPTION
## Summary

- treat a current or publishable `nanvix-python` mutation as final-tier SDK readiness
- dispatch the exact verified SDK version to `nanvix/distro` after tier-6 publication completes or is unnecessary
- suppress the candidate when the final consumer is blocked or any consumer mutation fails
- document the final-tier ownership contract

## Context

SDK publication precedes the dependency-tier fan-out by many hours. `nanvix/distro` should retry only from the central coordinator, not from individual port release workflows. Tier 6 already contains `nanvix-python`, whose dependency resolution proves that the preceding CPython chain has converged.

The distro still independently preflights every module, including its BusyBox and QuickJS leaves, so the coordinator event is a candidate signal rather than a replacement for release-set validation.

## Dependency

Receiver nanvix/distro#34 is merged and the repository has been renamed to `nanvix/distro`.

## Validation

- `tests/run-tests.sh` (17 checks)
- ShellCheck and shfmt
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/nanvix-update-nanvix.yml`
- direct valid/missing/malformed SDK payload checks
- `git diff --check`