### PR TITLE
[nanvix-ci] F: fix YAML fold breaking setup flags

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -556,13 +556,14 @@ jobs:
       - name: Setup (with Docker)
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN || github.token }}
-        run: nanvix-zutil setup \
-          --with-docker "$NANVIX_DOCKER_IMAGE" \
-          --target "${{ matrix.target-arch }}" \
-          --machine "${{ matrix.platform }}" \
-          --mode "${{ matrix.process-mode }}" \
-          --memory-size "${{ matrix.memory }}" \
-          --host "${{ matrix.host }}"
+        run: |
+          nanvix-zutil setup \
+            --with-docker "$NANVIX_DOCKER_IMAGE" \
+            --target "${{ matrix.target-arch }}" \
+            --machine "${{ matrix.platform }}" \
+            --mode "${{ matrix.process-mode }}" \
+            --memory-size "${{ matrix.memory }}" \
+            --host "${{ matrix.host }}"
 
       - name: Build (in Docker)
         run: nanvix-zutil build
@@ -694,13 +695,14 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN || github.token }}
         shell: pwsh
-        run: nanvix-zutil setup `
-          --with-docker "$env:NANVIX_DOCKER_IMAGE" `
-          --target "${{ fromJSON(inputs.target-archs)[0] }}" `
-          --machine "${{ matrix.platform }}" `
-          --mode standalone `
-          --memory-size "${{ matrix.memory }}" `
-          --host windows
+        run: |
+          nanvix-zutil setup `
+            --with-docker "$env:NANVIX_DOCKER_IMAGE" `
+            --target "${{ fromJSON(inputs.target-archs)[0] }}" `
+            --machine "${{ matrix.platform }}" `
+            --mode standalone `
+            --memory-size "${{ matrix.memory }}" `
+            --host windows
 
       - name: Download Linux build output
         if: ${{ !inputs.windows-build }}
@@ -806,13 +808,14 @@ jobs:
       - name: Setup (with Docker)
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN || github.token }}
-        run: nanvix-zutil setup \
-          --with-docker "$NANVIX_DOCKER_IMAGE" \
-          --target "${{ matrix.target-arch }}" \
-          --machine "${{ matrix.platform }}" \
-          --mode "${{ matrix.process-mode }}" \
-          --memory-size "${{ matrix.memory }}" \
-          --host linux
+        run: |
+          nanvix-zutil setup \
+            --with-docker "$NANVIX_DOCKER_IMAGE" \
+            --target "${{ matrix.target-arch }}" \
+            --machine "${{ matrix.platform }}" \
+            --mode "${{ matrix.process-mode }}" \
+            --memory-size "${{ matrix.memory }}" \
+            --host linux
 
       - name: Benchmark
         env:


### PR DESCRIPTION
## Problem

Since v3.0.2 (#128), all downstream `setup` calls started failing:

```
nanvix-zutil: error: unrecognized arguments:  --with-docker ghcr.io/...
 --target x86  --machine microvm  --mode standalone  --memory-size 256mb  --host linux
```

Affects both `linux-*` and `windows-*` build matrix legs across at least
nanvix-python (#359), and would hit every consumer on next SDK/zutils bump.

## Root cause

The four `nanvix-zutil setup ...` steps write `run:` as a **plain YAML
scalar** (no `|` block indicator):

```yaml
run: nanvix-zutil setup \
  --with-docker "$NANVIX_DOCKER_IMAGE" \
  --target "${{ matrix.target-arch }}" \
  ...
```

Plain multi-line scalars fold real newlines into a single space. By the
time this reaches the runner, it's one physical line, and the trailing
`\` (or `` ` `` in the pwsh variant) — meant to continue onto a real next
line — instead just escapes the *folded space*. Bash then tokenizes each
flag with a stray leading space glued on (`' --with-docker'` instead of
`'--with-docker'`), which argparse can't match against any known option,
hence "unrecognized arguments" for the entire flag list at once.

Verified locally: reproduced the exact broken tokenization with a real
`bash` invocation of the folded string, and confirmed the fix produces
clean argv.

## Fix

Add `run: |` to the four `nanvix-zutil setup` steps (build/linux,
build/windows via pwsh, benchmark) so the block is a literal scalar and
real newlines (and therefore real line continuations) survive.

`actionlint` passes.