### PR TITLE
fix: distinguish build artifacts by host

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -589,7 +589,7 @@ jobs:
         if: success()
         uses: actions/upload-artifact@v7
         with:
-          name: ${{ needs.get-nanvix-info.outputs.package_name }}-${{ needs.get-nanvix-info.outputs.package_version }}-${{ matrix.target-arch }}-${{ matrix.platform }}-${{ matrix.process-mode }}-${{ matrix.memory }}
+          name: ${{ needs.get-nanvix-info.outputs.package_name }}-${{ needs.get-nanvix-info.outputs.package_version }}-${{ matrix.host }}-${{ matrix.target-arch }}-${{ matrix.platform }}-${{ matrix.process-mode }}-${{ matrix.memory }}
           path: |
             ${{inputs.dist-path}}/*.tar.bz2
             ${{inputs.dist-path}}/*.tar.gz


### PR DESCRIPTION
Build matrix includes host dimension (linux/windows) but artifact upload name did not, causing collisions. Adds `matrix.host` to the artifact name so both host builds are preserved for release.

Fixes missing Windows artifacts in tier 1 releases.